### PR TITLE
Fix line highlight for long lines

### DIFF
--- a/src/utils/theme.css
+++ b/src/utils/theme.css
@@ -143,3 +143,12 @@ pre[data-line] {
   padding-left: 0.75em;
   border-left: 0.25em solid #ffa7c4;
 }
+
+.gatsby-highlight {
+  overflow: auto;
+}
+
+.gatsby-highlight pre[class*="language-"] {
+  float: left;
+  min-width: 100%;
+}


### PR DESCRIPTION
closes #11 

related issue: https://github.com/gatsbyjs/gatsby/issues/9092#issuecomment-429928369

working on my local workspace.

![localhost_8000_why-do-we-write-super-props_ iphone x](https://user-images.githubusercontent.com/3297859/49364171-a1c63080-f71e-11e8-8298-dd509102a48a.png)
