### PR TITLE
Remove mobile from twitter link

### DIFF
--- a/src/components/Bio.js
+++ b/src/components/Bio.js
@@ -27,7 +27,7 @@ class Bio extends React.Component {
           }}
         />
         <p style={{ maxWidth: 310 }}>
-          Personal blog by <a href="https://mobile.twitter.com/dan_abramov">Dan Abramov</a>.
+          Personal blog by <a href="https://twitter.com/dan_abramov">Dan Abramov</a>.
           {' '}
           I&nbsp;explain things with words and code.
         </p>


### PR DESCRIPTION
Clicking the link on a desktop will go to the mobile twitter and should go to normal twitter instead.