### PR TITLE
feat: add seo/twitter component for twitter cards, og tags, etc.

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -2,11 +2,12 @@ module.exports = {
   siteMetadata: {
     title: 'Overreacted',
     author: 'Dan Abramov',
-    description: 'I write words and code to explain things to myself and others.',
-    siteUrl: 'https://overreacted.io/',
+    description:
+      'I write words and code to explain things to myself and others.',
+    siteUrl: 'https://overreacted.io',
     social: {
-      twitter: '@gaeron'
-    }
+      twitter: '@gaeron',
+    },
   },
   pathPrefix: '/',
   plugins: [
@@ -36,8 +37,8 @@ module.exports = {
           {
             resolve: 'gatsby-remark-prismjs',
             options: {
-              inlineCodeMarker: '÷'
-            }
+              inlineCodeMarker: '÷',
+            },
           },
           'gatsby-remark-copy-linked-files',
           'gatsby-remark-smartypants',

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -4,6 +4,9 @@ module.exports = {
     author: 'Dan Abramov',
     description: 'I write words and code to explain things to myself and others.',
     siteUrl: 'https://overreacted.io/',
+    social: {
+      twitter: '@gaeron'
+    }
   },
   pathPrefix: '/',
   plugins: [

--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -57,7 +57,7 @@ function SEO({ meta, image, title, description }) {
               },
               {
                 name: 'twitter:creator',
-                content: `@${siteMetadata.social.twitter}`,
+                content: siteMetadata.social.twitter,
               },
               {
                 name: 'twitter:title',

--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -102,7 +102,7 @@ SEO.defaultProps = {
 }
 
 SEO.propTypes = {
-  descrpition: PropTypes.string,
+  description: PropTypes.string,
   image: PropTypes.string,
   meta: PropTypes.array,
   slug: PropTypes.string,

--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -1,0 +1,105 @@
+import React from 'react'
+import Helmet from 'react-helmet'
+import PropTypes from 'prop-types'
+import { StaticQuery, graphql } from 'gatsby'
+
+const query = graphql`
+  query GetSiteMetadata {
+    site {
+      siteMetadata {
+        title
+        author
+        description
+        siteUrl
+        social {
+          twitter
+        }
+      }
+    }
+  }
+`
+
+function SEO({ meta, image, title, description }) {
+  return (
+    <StaticQuery
+      query={query}
+      render={data => {
+        const { siteMetadata } = data.site
+        const metaDescription = description || siteMetadata.description
+        const metaImage = image ? `${siteMetadata.siteUrl}${image}` : null
+        return (
+          <Helmet
+            htmlAttributes={{ lang: 'en' }}
+            {...(title
+              ? {
+                  titleTemplate: `%s - ${siteMetadata.title}`,
+                  title,
+                }
+              : {
+                  title: siteMetadata.title,
+                })}
+            meta={[
+              {
+                name: 'description',
+                content: metaDescription,
+              },
+              {
+                property: 'og:title',
+                content: title,
+              },
+              {
+                name: 'og:description',
+                content: metaDescription,
+              },
+              {
+                name: 'twitter:card',
+                content: 'summary',
+              },
+              {
+                name: 'twitter:creator',
+                content: `@${siteMetadata.social.twitter}`,
+              },
+              {
+                name: 'twitter:title',
+                content: title,
+              },
+              {
+                name: 'twitter:description',
+                content: metaDescription,
+              },
+            ]
+              .concat(
+                metaImage
+                  ? [
+                      {
+                        property: 'og:image',
+                        content: metaImage,
+                      },
+                      {
+                        name: 'twitter:image',
+                        content: metaImage,
+                      },
+                    ]
+                  : []
+              )
+              .concat(meta)}
+          />
+        )
+      }}
+    />
+  )
+}
+
+SEO.defaultProps = {
+  meta: [],
+  title: ``,
+}
+
+SEO.propTypes = {
+  descrpition: PropTypes.string,
+  image: PropTypes.string,
+  meta: PropTypes.array,
+  title: PropTypes.string.isRequired,
+}
+
+export default SEO

--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -19,14 +19,15 @@ const query = graphql`
   }
 `
 
-function SEO({ meta, image, title, description }) {
+function SEO({ meta, image, title, description, slug }) {
   return (
     <StaticQuery
       query={query}
       render={data => {
         const { siteMetadata } = data.site
         const metaDescription = description || siteMetadata.description
-        const metaImage = image ? `${siteMetadata.siteUrl}${image}` : null
+        const metaImage = image ? `${siteMetadata.siteUrl}/${image}` : null
+        const url = `${siteMetadata.siteUrl}${slug}`
         return (
           <Helmet
             htmlAttributes={{ lang: 'en' }}
@@ -42,6 +43,10 @@ function SEO({ meta, image, title, description }) {
               {
                 name: 'description',
                 content: metaDescription,
+              },
+              {
+                property: 'og:url',
+                content: url,
               },
               {
                 property: 'og:title',
@@ -92,13 +97,15 @@ function SEO({ meta, image, title, description }) {
 
 SEO.defaultProps = {
   meta: [],
-  title: ``,
+  title: '',
+  slug: '',
 }
 
 SEO.propTypes = {
   descrpition: PropTypes.string,
   image: PropTypes.string,
   meta: PropTypes.array,
+  slug: PropTypes.string,
   title: PropTypes.string.isRequired,
 }
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -19,7 +19,7 @@ class BlogIndex extends React.Component {
 
     return (
       <Layout location={this.props.location} title={siteTitle}>
-        <SEO title={``} />
+        <SEO />
         <Bio />
         {posts.map(({ node }) => {
           const title = get(node, 'frontmatter.title') || node.fields.slug

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,10 +1,10 @@
 import React from 'react'
 import { Link, graphql } from 'gatsby'
 import get from 'lodash/get'
-import Helmet from 'react-helmet'
 
 import Bio from '../components/Bio'
 import Layout from '../components/Layout'
+import SEO from '../components/SEO'
 import { formatReadingTime } from '../utils/helpers'
 import { rhythm } from '../utils/typography'
 
@@ -19,11 +19,7 @@ class BlogIndex extends React.Component {
 
     return (
       <Layout location={this.props.location} title={siteTitle}>
-        <Helmet
-          htmlAttributes={{ lang: 'en' }}
-          meta={[{ name: 'description', content: siteDescription }]}
-          title={siteTitle}
-        />
+        <SEO title={``} />
         <Bio />
         {posts.map(({ node }) => {
           const title = get(node, 'frontmatter.title') || node.fields.slug
@@ -42,7 +38,9 @@ class BlogIndex extends React.Component {
                 {node.frontmatter.date}
                 {` • ${formatReadingTime(node.timeToRead)}`}
               </small>
-              <p dangerouslySetInnerHTML={{ __html: node.frontmatter.spoiler }} />
+              <p
+                dangerouslySetInnerHTML={{ __html: node.frontmatter.spoiler }}
+              />
             </div>
           )
         })}

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -16,7 +16,11 @@ class BlogPostTemplate extends React.Component {
 
     return (
       <Layout location={this.props.location} title={siteTitle}>
-        <SEO title={post.frontmatter.title} description={post.excerpt} />
+        <SEO
+          title={post.frontmatter.title}
+          description={post.excerpt}
+          slug={post.fields.slug}
+        />
         <h1>{post.frontmatter.title}</h1>
         <p
           style={{
@@ -84,6 +88,9 @@ export const pageQuery = graphql`
       frontmatter {
         title
         date(formatString: "MMMM DD, YYYY")
+      }
+      fields {
+        slug
       }
     }
   }

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -1,10 +1,10 @@
 import React from 'react'
-import Helmet from 'react-helmet'
 import { Link, graphql } from 'gatsby'
 import get from 'lodash/get'
 
 import Bio from '../components/Bio'
 import Layout from '../components/Layout'
+import SEO from '../components/SEO'
 import { formatReadingTime } from '../utils/helpers'
 import { rhythm, scale } from '../utils/typography'
 
@@ -12,16 +12,11 @@ class BlogPostTemplate extends React.Component {
   render() {
     const post = this.props.data.markdownRemark
     const siteTitle = get(this.props, 'data.site.siteMetadata.title')
-    const siteDescription = post.excerpt
     const { previous, next } = this.props.pageContext
 
     return (
       <Layout location={this.props.location} title={siteTitle}>
-        <Helmet
-          htmlAttributes={{ lang: 'en' }}
-          meta={[{ name: 'description', content: siteDescription }]}
-          title={`${post.frontmatter.title} | ${siteTitle}`}
-        />
+        <SEO title={post.frontmatter.title} description={post.excerpt} />
         <h1>{post.frontmatter.title}</h1>
         <p
           style={{


### PR DESCRIPTION
Fixes #4 

This PR adds an (automatic, mostly) twitter card capability, as well as some other general SEO goodness.

There's more to do here, but I didn't want to scope creep. Specifically, I think the following are worth doing:

- Move posts to content/ (better fit than pages), and cleans up directory structure a bit
- Add images/featured images to post, and inject them with GraphQL, pass to the SEO component (this will improve the twitter cards)
  - This is set up, just didn't add any images yet