### PR TITLE
Fix inline code selection styles

### DIFF
--- a/src/utils/theme.css
+++ b/src/utils/theme.css
@@ -45,19 +45,6 @@ pre[class*="language-"]::selection {
   background: hsl(207, 4%, 16%);
 }
 
-/* Text Selection colour */
-pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
-code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
-  text-shadow: none;
-  background: hsla(0, 0%, 93%, 0.15);
-}
-
-pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
-code[class*="language-"]::selection, code[class*="language-"] ::selection {
-  text-shadow: none;
-  background: hsla(0, 0%, 93%, 0.15);
-}
-
 /* Inline code */
 :not(pre) > code[class*="language-"] {
   border-radius: .3em;

--- a/src/utils/theme.css
+++ b/src/utils/theme.css
@@ -45,6 +45,17 @@ pre[class*="language-"]::selection {
   background: hsl(207, 4%, 16%);
 }
 
+/* Text Selection colour */
+pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection {
+  text-shadow: none;
+  background: hsla(0, 0%, 100%, 0.15);
+}
+
+pre[class*="language-"]::selection, pre[class*="language-"] ::selection {
+  text-shadow: none;
+  background: hsla(0, 0%, 100%, 0.15);
+}
+
 /* Inline code */
 :not(pre) > code[class*="language-"] {
   border-radius: .3em;


### PR DESCRIPTION
As [mentioned on Twitter](https://twitter.com/HugoGiraudel/status/1069991265482223616), inline code are not properly highlighted when part of the selected text. It’s not too problematic when selecting an entire paragraph, but is a bit of an issue when selecting inline code directly, as it is not visually highlighted at all.

Removing these declarations should fix the issue without impacting the rest of the design. :)