### PR TITLE
Fixes form input variable names

### DIFF
--- a/src/pages/why-do-hooks-rely-on-call-order.md
+++ b/src/pages/why-do-hooks-rely-on-call-order.md
@@ -355,8 +355,8 @@ Additionally, you have to repeat every custom Hook used in a component twice. On
 
 ```js{2,3,7,8}
 // ⚠️ This is NOT the React Hooks API
-const useNameInput = createUseFormInput();
-const useSurnameInput = createUseFormInput();
+const useNameFormInput = createUseFormInput();
+const useSurnameFormInput = createUseFormInput();
 
 function Form() {
   // ...


### PR DESCRIPTION
Fixes the form input variable names:

- `useNameInput ` -> `useNameFormInput`
- `useSurnameInput ` -> `useSurnameFormInput`