### PR TITLE
align the next link to the right side of page

### DIFF
--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -71,21 +71,17 @@ class BlogPostTemplate extends React.Component {
         <Bio />
         <ul
           style={{
-            display: 'flex',
-            flexWrap: 'wrap',
-            justifyContent: 'space-between',
             listStyle: 'none',
-            padding: 0,
           }}
         >
-          <li>
+          <li style={{float: 'left'}}>
             {previous && (
               <Link to={previous.fields.slug} rel="prev">
                 ← {previous.frontmatter.title}
               </Link>
             )}
           </li>
-          <li>
+          <li style={{float: 'right'}}>
             {next && (
               <Link to={next.fields.slug} rel="next">
                 {next.frontmatter.title} →


### PR DESCRIPTION
Whenever the prev, next links are long they are stacking one after another and both are left aligned.
I found it is harder to find which one is previous and which one is next despite having the arrows.
<img width="664" alt="screen shot 2018-12-15 at 7 28 48 pm" src="https://user-images.githubusercontent.com/9403543/50046205-eac3a080-009f-11e9-9b18-025d99be2bac.png">

making the next link to align to the right of the page makes is easy to understand.
<img width="675" alt="screen shot 2018-12-15 at 7 32 19 pm" src="https://user-images.githubusercontent.com/9403543/50046221-3f671b80-00a0-11e9-8622-a6fc07a4d88d.png">

