### PR TITLE
Change useOnlineStatus to useNetworkStatus in "Why do react hooks rely on call order"

### DIFF
--- a/src/pages/why-do-hooks-rely-on-call-order.md
+++ b/src/pages/why-do-hooks-rely-on-call-order.md
@@ -248,7 +248,7 @@ This is technically the same flaw as the previous one but it’s worth mentionin
 
 Our own mixin system [suffered from it](https://reactjs.org/blog/2016/07/13/mixins-considered-harmful.html#mixins-cause-name-clashes).
 
-Two custom Hooks like `useWindowWidth()` and `useOnlineStatus()` might want to use the same custom Hook like `useSubscription()` under the hood:
+Two custom Hooks like `useWindowWidth()` and `useNetworkStatus()` might want to use the same custom Hook like `useSubscription()` under the hood:
 
 ```jsx{12,23-27,32-42}
 function StatusMessage() {


### PR DESCRIPTION
In "Why do react hooks rely on call order", Flaw #4: The Diamond Problem, there's a code example, 
the hook name is `useNetworkStatus` and not `useOnlineStatus`.