### PR TITLE
Fix discussUrl for better UI in Desktop view

### DIFF
--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -21,7 +21,7 @@ class BlogPostTemplate extends React.Component {
       /\//g,
       ''
     )}.md`
-    const discussUrl = `https://mobile.twitter.com/search?q=${encodeURIComponent(`https://overreacted.io${slug}`)}`
+    const discussUrl = `https://www.twitter.com/search?q=${encodeURIComponent(`https://overreacted.io${slug}`)}`
     return (
       <Layout location={this.props.location} title={siteTitle}>
         <SEO


### PR DESCRIPTION
Change 'mobile.twitter.com' to "www.twitter.com". When 'www.twitter.com' is opened in mobile, it will just automatically redirect to 'mobile.twitter.com'.