### PR TITLE
add link to bottom of RSS feed articles

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -111,7 +111,7 @@ module.exports = {
               }
             `,
             output: '/rss.xml',
-            title: 'Dan Abramov Overreacted Blog RSS Feed',
+            title: 'Dan Abramov\'s Overreacted Blog RSS Feed',
           },
         ],
       },

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -53,7 +53,69 @@ module.exports = {
         trackingId: `UA-130227707-1`,
       },
     },
-    `gatsby-plugin-feed`,
+    {
+      resolve: `gatsby-plugin-feed`,
+      options: {
+        query: `
+          {
+            site {
+              siteMetadata {
+                title
+                description
+                siteUrl
+                site_url: siteUrl
+              }
+            }
+          }
+        `,
+        feeds: [
+          {
+            serialize: ({ query: { site, allMarkdownRemark } }) => {
+              return allMarkdownRemark.edges.map(edge => {
+                const postText = `
+                <div style="margin-top=55px; font-style: italic;">[This is an article posted to my blog at overreacted.io. You can read it online by <a href="${site
+                  .siteMetadata.siteUrl +
+                  edge.node.fields.slug}">clicking here.]</a></div>
+              `
+                return Object.assign({}, edge.node.frontmatter, {
+                  description: edge.node.excerpt,
+                  date: edge.node.fields.date,
+                  url: site.siteMetadata.siteUrl + edge.node.fields.slug,
+                  guid: site.siteMetadata.siteUrl + edge.node.fields.slug,
+                  custom_elements: [
+                    { 'content:encoded': edge.node.html + postText },
+                  ],
+                })
+              })
+            },
+            query: `
+              {
+                allMarkdownRemark(
+                  limit: 1000,
+                  sort: { order: DESC, fields: [frontmatter___date] }
+                ) {
+                  edges {
+                    node {
+                      excerpt(pruneLength: 250)
+                      html
+                      fields { 
+                        slug   
+                      }
+                      frontmatter {
+                        title
+                        date
+                      }
+                    }
+                  }
+                }
+              }
+            `,
+            output: '/rss.xml',
+            title: 'Dan Abramov Overreacted Blog RSS Feed',
+          },
+        ],
+      },
+    },
     {
       resolve: `gatsby-plugin-manifest`,
       options: {


### PR DESCRIPTION
This adds a link back to the article for the RSS feed. This is useful so articles that are automatically published via ConverKit include a link to the source.