### PR TITLE
Filters out non-english posts from RSS feed.

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -104,6 +104,7 @@ module.exports = {
                 allMarkdownRemark(
                   limit: 1000,
                   sort: { order: DESC, fields: [frontmatter___date] }
+                  filter: {fields: { slug : {regex: "/^\/(?!([a-z]{2}(?:_[A-Z]{2})?\/)).*\/$/gm"}}}
                 ) {
                   edges {
                     node {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -104,7 +104,7 @@ module.exports = {
                 allMarkdownRemark(
                   limit: 1000,
                   sort: { order: DESC, fields: [frontmatter___date] }
-                  filter: {fields: { slug : {regex: "/^\/(?!([a-z]{2}(?:_[A-Z]{2})?\/)).*\/$/gm"}}}
+                  filter: {fields: { langKey: {eq: "en"}}}
                 ) {
                   edges {
                     node {


### PR DESCRIPTION
This solution is a little yucky because it relies on a regex based on slug conventions, but it seems to work. Fixes #72