### PR TITLE
Amend font-size of <code> block inside <p> to 1rem

### DIFF
--- a/src/utils/typography.js
+++ b/src/utils/typography.js
@@ -12,7 +12,7 @@ Wordpress2016.overrideThemeStyles = () => ({
     boxShadow: 'none',
   },
   'p code': {
-    fontSize: '1.1rem'
+    fontSize: '1rem',
   },
   'li code': {
     fontSize: '1rem'


### PR DESCRIPTION
## Done

Tweaked the font-size override of code blocks inside paragraphs to match font-size of the surrounding text.

Before this change:

<img width="671" alt="screenshot 2019-01-16 at 19 19 41" src="https://user-images.githubusercontent.com/505570/51273289-43020100-19c4-11e9-8fb7-846be1cdd000.png">

After this change:

<img width="684" alt="screenshot 2019-01-16 at 19 18 54" src="https://user-images.githubusercontent.com/505570/51273315-5319e080-19c4-11e9-8dcd-27f473eabf0f.png">

## How to QA

- Run the site with `yarn dev`
- View a blog post with code snippets e.g. http://localhost:8000/why-do-hooks-rely-on-call-order/
- Verify inline code blocks match the font-size of surrounding text

Fixes #20
