### PR TITLE
fix global graphql deprecation warnings

### DIFF
--- a/src/pages/confirm.js
+++ b/src/pages/confirm.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Layout from '../components/Layout';
 import get from 'lodash/get';
+import { graphql } from 'gatsby';
 
 class Confirm extends React.Component {
   render() {

--- a/src/pages/thanks.js
+++ b/src/pages/thanks.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Layout from '../components/Layout';
 import get from 'lodash/get';
+import { graphql } from 'gatsby';
 
 class Thanks extends React.Component {
   render() {


### PR DESCRIPTION
I noticed that there were a few deprecation errors when running `yarn start` so figured it was worth fixing them 🛠 

https://github.com/gatsbyjs/gatsby/blob/master/docs/docs/migrating-from-v1-to-v2.md#import-graphql-from-gatsby