### PR TITLE
Align header contents to baseline without ugly hacks - Fix for #134

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -25,7 +25,7 @@ class Layout extends React.Component {
         <h1
           style={{
             ...scale(0.75),
-            marginBottom: rhythm(1.5),
+            marginBottom: 0,
             marginTop: 0,
           }}
         >
@@ -47,8 +47,9 @@ class Layout extends React.Component {
           style={{
             fontFamily: 'Montserrat, sans-serif',
             marginTop: 0,
-            marginBottom: rhythm(-1),
-            minHeight: '3.5rem',
+            marginBottom: 0,
+            height: 42,
+            lineHeight: '50px',
           }}
         >
           <Link
@@ -66,12 +67,7 @@ class Layout extends React.Component {
     }
   }
   render() {
-    const { children, location } = this.props;
-    const rootPath = `${__PATH_PREFIX__}/`;
-    const isHomePage = location.pathname === rootPath;
-    // Keep dark/light mode switch aligned between home and post page
-    // Does this make sense? No.
-    const topPadding = isHomePage ? rhythm(1.5) : '50px';
+    const { children } = this.props;
 
     return (
       <div
@@ -86,14 +82,15 @@ class Layout extends React.Component {
             marginLeft: 'auto',
             marginRight: 'auto',
             maxWidth: rhythm(24),
-            padding: `${topPadding} ${rhythm(3 / 4)}`,
+            padding: `50px ${rhythm(3 / 4)}`,
           }}
         >
           <div
             style={{
               display: 'flex',
               justifyContent: 'space-between',
-              alignItems: 'baseline',
+              alignItems: 'center',
+              marginBottom: '2.625rem',
             }}
           >
             {this.renderHeader()}


### PR DESCRIPTION
So this is my proposed solution for issue #134 where an ugly hack was being used to fix header alignment.

What this commit does is:

- Move margins from the inside of the header to the outer wrapper
- Stabilise height between headers
- Remove min-heights and other things that can make header layout brittle
- And of course, remove the hack

Hope this helps.