### PR TITLE
L10n : use post locale for header date formatting

### DIFF
--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -7,7 +7,7 @@ import Bio from '../components/Bio';
 import Layout from '../components/Layout';
 import SEO from '../components/SEO';
 import Signup from '../components/Signup';
-import { formatReadingTime } from '../utils/helpers';
+import { formatPostDate, formatReadingTime } from '../utils/helpers';
 import { rhythm, scale } from '../utils/typography';
 import {
   codeToLanguage,
@@ -109,7 +109,7 @@ class BlogPostTemplate extends React.Component {
             marginTop: rhythm(-4 / 5),
           }}
         >
-          {post.frontmatter.date}
+          {formatPostDate(post.frontmatter.date, lang)}
           {` • ${formatReadingTime(post.timeToRead)}`}
         </p>
         {translations.length > 0 && (

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -9,7 +9,7 @@ export function formatPostDate(date, lang) {
     return date;
   }
 
-  date = new Date();
+  date = new Date(date);
   const args = [
     lang,
     { day: 'numeric', month: 'long', year: 'numeric' },

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -2,3 +2,17 @@ export function formatReadingTime(minutes) {
   let cups = Math.round(minutes / 5);
   return `${new Array(cups || 1).fill('☕️').join('')} ${minutes} min read`;
 }
+
+// `lang` is optional and will default to the current user agent locale
+export function formatPostDate(date, lang) {
+  if (typeof Date.prototype.toLocaleDateString !== 'function') {
+    return date;
+  }
+
+  date = new Date();
+  const args = [
+    lang,
+    { day: 'numeric', month: 'long', year: 'numeric' },
+  ].filter(Boolean);
+  return date.toLocaleDateString(...args);
+}


### PR DESCRIPTION
It's jarring that a translated post's header uses English for the date still. This tentative fix uses the ES402 / `Intl` API, when available, to turn the frontmatter’s date into a similar-choices localized date string based on the post's language.

Note that ES402 is supposted (enough) [across all major browsers](https://kangax.github.io/compat-table/esintl/)