### PR TITLE
why-isnt-x-a-hook: Fix ChatAPI call in useEffect

### DIFF
--- a/src/pages/why-isnt-x-a-hook/index.md
+++ b/src/pages/why-isnt-x-a-hook/index.md
@@ -147,7 +147,7 @@ function useFriendStatus(friendID) {
   useEffect(() => {
     const handleStatusChange = status => setIsOnline(status.isOnline);
     ChatAPI.subscribe(friendID, handleStatusChange);
-    return () => ChatAPI.subscribe(friendID, handleStatusChange);
+    return () => ChatAPI.unsubscribe(friendID, handleStatusChange);
   });
 
   return isOnline;


### PR DESCRIPTION
In the effect undo function it should unsubscribe to reverse the subscribe.