### PR TITLE
fix overscroll background

### DIFF
--- a/src/utils/global.css
+++ b/src/utils/global.css
@@ -1,5 +1,6 @@
 body {
   --pink: rgb(255, 167, 196);
+  background-color: var(--bg);
 }
 
 body.light {


### PR DESCRIPTION
just a pet peeve: when in dark mode, scrolling outside the content shows a white background.

tested browsers that exhibit this issue: chrome (mac), safari (both iOS and mac), maybe others.

| ![before](https://user-images.githubusercontent.com/8649362/51796906-a6203e80-21e1-11e9-97ed-fad39b4cfbf7.png) | ![after](https://user-images.githubusercontent.com/8649362/51796908-a9b3c580-21e1-11e9-98b2-dd80f1ad23ec.png) |
|:---:|:---:|
| **before:** 😕 `⬜️⬛️`  | **after:** 👌 `⬛️⬛️`  |
