### PR TITLE
Linkify internal posts and use translations

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -151,5 +151,6 @@ module.exports = {
         useLangKeyLayout: false,
       },
     },
+    `gatsby-plugin-catch-links`,
   ],
 };

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -37,6 +37,7 @@ exports.createPages = ({ graphql, actions }) => {
                     slug
                     langKey
                     directoryName
+                    maybeAbsoluteLinks
                   }
                   frontmatter {
                     title
@@ -55,6 +56,14 @@ exports.createPages = ({ graphql, actions }) => {
 
         // Create blog posts pages.
         const posts = result.data.allMarkdownRemark.edges;
+        const allSlugs = _.reduce(
+          posts,
+          (result, post) => {
+            result.add(post.node.fields.slug);
+            return result;
+          },
+          new Set()
+        );
 
         const translationsByDirectory = _.reduce(
           posts,
@@ -95,6 +104,7 @@ exports.createPages = ({ graphql, actions }) => {
               previous,
               next,
               translations,
+              translatedLinks: [],
             },
           });
 
@@ -105,12 +115,28 @@ exports.createPages = ({ graphql, actions }) => {
             const translations =
               translationsByDirectory[_.get(post, 'node.fields.directoryName')];
 
+            // Record which links to internal posts have translated versions
+            // into this language. We'll replace them before rendering HTML.
+            let translatedLinks = [];
+            const { langKey, maybeAbsoluteLinks } = post.node.fields;
+            maybeAbsoluteLinks.forEach(link => {
+              if (
+                // This is legit an internal post link,
+                // and it has been already translated.
+                allSlugs.has(link) &&
+                allSlugs.has('/' + langKey + link)
+              ) {
+                translatedLinks.push(link);
+              }
+            });
+
             createPage({
               path: post.node.fields.slug,
               component: blogPost,
               context: {
                 slug: post.node.fields.slug,
                 translations,
+                translatedLinks,
               },
             });
           });
@@ -128,6 +154,26 @@ exports.onCreateNode = ({ node, actions }) => {
       node,
       name: 'directoryName',
       value: path.basename(path.dirname(_.get(node, 'fileAbsolutePath'))),
+    });
+
+    // Capture a list of what looks to be absolute internal links.
+    // We'll later remember which of them have translations,
+    // and use that to render localized internal links when available.
+
+    // TODO: check against links with no trailing slashes
+    // or that already link to translations.
+    const markdown = node.internal.content;
+    let maybeAbsoluteLinks = [];
+    let linkRe = /\]\((\/[^\)]+)\)/g;
+    let match = linkRe.exec(markdown);
+    while (match != null) {
+      maybeAbsoluteLinks.push(match[1]);
+      match = linkRe.exec(markdown);
+    }
+    createNodeField({
+      node,
+      name: 'maybeAbsoluteLinks',
+      value: maybeAbsoluteLinks,
     });
   }
 };

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "gatsby": "^2.0.76",
+    "gatsby-plugin-catch-links": "^2.0.9",
     "gatsby-plugin-feed": "^2.0.8",
     "gatsby-plugin-google-analytics": "^2.0.5",
     "gatsby-plugin-i18n": "^0.4.2",

--- a/src/pages/how-does-react-tell-a-class-from-a-function/index.fr.md
+++ b/src/pages/how-does-react-tell-a-class-from-a-function/index.fr.md
@@ -64,7 +64,7 @@ Dans les deux cas, l’objectif de React est d’obtenir le nœud rendu (dans ce
 
 **Alors comment React sait-il si quelque chose est une classe ou une fonction ?**
 
-Tout comme dans mon [précédent article](/fr/why-do-we-write-super-props/), **vous n’avez pas *besoin* de savoir ça pour être efficace avec React.**  Je ne le savais pas moi-même pendant des années.  Ne faites pas de cet article une question d’entretien technique.  En fait, cet article est plus à propos de JavaScript que de React.
+Tout comme dans mon [précédent article](/why-do-we-write-super-props/), **vous n’avez pas *besoin* de savoir ça pour être efficace avec React.**  Je ne le savais pas moi-même pendant des années.  Ne faites pas de cet article une question d’entretien technique.  En fait, cet article est plus à propos de JavaScript que de React.
 
 Ce blog est pour les personnes curieuses qui veulent savoir *pourquoi* React fonctionne d’une certaine manière.  Êtes-vous une telle personne ?  Alors creusons ensemble.
 

--- a/src/pages/how-does-setstate-know-what-to-do/index.fr.md
+++ b/src/pages/how-does-setstate-know-what-to-do/index.fr.md
@@ -42,7 +42,7 @@ La mise à jour du DOM semble faire partie des responsabilités de React DOM.  M
 
 Alors comment `setState()`, au sein de `React.Component`, peut-elle mettre à jour le DOM ?
 
-**Avertissement : tout comme [la plupart](/fr/why-do-react-elements-have-typeof-property/) des [autres](/fr/how-does-react-tell-a-class-from-a-function/) [articles](/fr/why-do-we-write-super-props/) de ce blog, vous n’avez pas vraiment *besoin* de savoir tout ça pour être efficace avec React. Cet article est plus pour les personnes qui aiment voir ce qu’il y a derrière le rideau.  C’est complètement optionnel !**
+**Avertissement : tout comme [la plupart](/why-do-react-elements-have-typeof-property/) des [autres](/how-does-react-tell-a-class-from-a-function/) [articles](/why-do-we-write-super-props/) de ce blog, vous n’avez pas vraiment *besoin* de savoir tout ça pour être efficace avec React. Cet article est plus pour les personnes qui aiment voir ce qu’il y a derrière le rideau.  C’est complètement optionnel !**
 
 ---
 

--- a/src/pages/the-elements-of-ui-engineering/index.fr.md
+++ b/src/pages/the-elements-of-ui-engineering/index.fr.md
@@ -4,7 +4,7 @@ date: '2018-12-30'
 spoiler: Qu’est-ce qui rend l’ingénierie UI délicate ?
 ---
 
-Dans mon [article précédent](/fr/things-i-dont-know-as-of-2018/), je parlais d’admettre les lacunes dans nos connaissances. Vous pourriez en conclure que je suggère de se résigner à la médiocrité. Il n’en est rien ! C’est juste que nous travaillons dans un domaine extrêmement vaste.
+Dans mon [article précédent](/things-i-dont-know-as-of-2018/), je parlais d’admettre les lacunes dans nos connaissances. Vous pourriez en conclure que je suggère de se résigner à la médiocrité. Il n’en est rien ! C’est juste que nous travaillons dans un domaine extrêmement vaste.
 
 Je suis fermement convaincu qu’on peut « commencer n’importe où » et que vous n’avez pas besoin d’apprendre les technologies dans un ordre particulier. Mais j’accorde aussi une grande valeur au développement d’une expertise. Personnellement, j’ai toujours été principalement intéressé par la création d’interfaces utilisateurs.
 
@@ -46,7 +46,7 @@ Si vous avez déjà travaillé sur une interface utilisateur, vous avez sans dou
 
 - **Résilience.** Vous aimez peut-être les bugs _(insectes, NdT)_ si vous êtes féru·e d’entomologie, mais je doute qu’ils vous éclatent au sein de vos programmes. Et pourtant, certains de vos bugs atterriront inévitablement en production. Que se passe-t-il alors ? Certains bugs causeront un comportement certes incorrect mais bien défini. Par exemple, peut-être que votre code produit un affichage incorrect sous certaines conditions. Mais si le code de rendu *plante* ? On ne peut plus raisonnablement continuer puisque l’affichage est incohérent. Un plantage au sein du rendu d’un article ne devrait pas « massacrer » le flux complet, ou le placer dans un état semi-cassé qui entraînerait sûrement d’autres plantages par la suite. Comment écrire du code de façon à isoler les échecs de rendu et de récupération de données, pour que le reste de l’appli puisse continuer à tourner ? Comment introduit-on de la tolérance à l’erreur dans des interfaces utilisateurs ?
 
-- **Abstraction.** Dans une toute petite appli, on peut coder en dur plein de cas spéciaux pour traiter les problèmes énumérés ci-dessus. Mais les applis ont tendance à grossir. On veut continuer à pouvoir [réutiliser, décliner, et refusionner](/fr/optimized-for-change/) des parties de notre code, et travailler dessus à plusieurs. On veut pouvoir définir des frontières claires entre les périmètres de compétence des différents contributeurs, afin d’éviter de rigidifier des logiques applicatives qui pourraient évoluer souvent. Comment créer des abstractions qui masquent les détails d’implémentation d’une partie donnée de l’UI ? Comment éviter de voir des problèmes résolus refaire surface au fil de la croissance de notre appli ?
+- **Abstraction.** Dans une toute petite appli, on peut coder en dur plein de cas spéciaux pour traiter les problèmes énumérés ci-dessus. Mais les applis ont tendance à grossir. On veut continuer à pouvoir [réutiliser, décliner, et refusionner](/optimized-for-change/) des parties de notre code, et travailler dessus à plusieurs. On veut pouvoir définir des frontières claires entre les périmètres de compétence des différents contributeurs, afin d’éviter de rigidifier des logiques applicatives qui pourraient évoluer souvent. Comment créer des abstractions qui masquent les détails d’implémentation d’une partie donnée de l’UI ? Comment éviter de voir des problèmes résolus refaire surface au fil de la croissance de notre appli ?
 
 ---
 

--- a/src/pages/why-do-hooks-rely-on-call-order/index.fr.md
+++ b/src/pages/why-do-hooks-rely-on-call-order/index.fr.md
@@ -34,7 +34,7 @@ Le premier—et sans doute le plus grand—choc lorsque vous découvrez les Hook
 
 Cette décision est évidemment controversée.  C’est pourquoi, [contrairement à nos principes](https://www.reddit.com/r/reactjs/comments/9xs2r6/sebmarkbages_response_to_hooks_rfc_feedback/e9wh4um/), nous avons publié la proposition seulement une fois que nous estimions que la documentation et nos présentations faisaient un travail d’explication suffisamment bon pour que les gens lui donnent une chance.
 
-**Si vous avez des réserves sur certains aspects de la conception de l’API des Hooks, je ne saurais trop vous recommander la lecture de [la réponse détaillée](https://github.com/reactjs/rfcs/pull/68#issuecomment-439314884) de Sebastian à la discussion RFC, qui dépasse les 1 300 commentaires.**  Elle est très complète, mais aussi assez dense.  Je pourrais sans doute transformer chacun de ses paragraphes en un article dédié sur ce blog.  (En fait, je l’ai [déjà fait](/fr/how-does-setstate-know-what-to-do/) une fois !)
+**Si vous avez des réserves sur certains aspects de la conception de l’API des Hooks, je ne saurais trop vous recommander la lecture de [la réponse détaillée](https://github.com/reactjs/rfcs/pull/68#issuecomment-439314884) de Sebastian à la discussion RFC, qui dépasse les 1 300 commentaires.**  Elle est très complète, mais aussi assez dense.  Je pourrais sans doute transformer chacun de ses paragraphes en un article dédié sur ce blog.  (En fait, je l’ai [déjà fait](/how-does-setstate-know-what-to-do/) une fois !)
 
 Aujourd’hui j’aimerais aborder un point particulier.  Comme vous vous en souvenez peut-être, chaque Hook peut être utilisé dans un composant plus d’une fois.  Par exemple, nous pouvons déclarer [plusieurs variables d’état](https://reactjs.org/docs/hooks-state.html#tip-using-multiple-state-variables) en utilisant `useState()` à chaque fois :
 
@@ -151,7 +151,7 @@ D’accord, vous ne serez sans doute pas tentés d’appeler `useState('name')` 
 
 Avec ce type de proposition, chaque fois que vous ajoutez une variable d’état dans un Hook personnalisé, vous risquez de casser les composants qui vous utilisent (directement ou transitivement) *parce qu’ils utilisent peut-être déjà le même nom* dans leurs propres variables d’état.
 
-C’est l’exemple même d’une API qui n’est pas [optimisée pour le changement](/fr/optimized-for-change/). Le code actuel semble peut-être « élégant », mais il réagirait mal à des changements de specs pour votre application. Ce serait bien qu’on [apprenne](https://reactjs.org/blog/2016/07/13/mixins-considered-harmful.html#mixins-cause-name-clashes) de nos erreurs.
+C’est l’exemple même d’une API qui n’est pas [optimisée pour le changement](/optimized-for-change/). Le code actuel semble peut-être « élégant », mais il réagirait mal à des changements de specs pour votre application. Ce serait bien qu’on [apprenne](https://reactjs.org/blog/2016/07/13/mixins-considered-harmful.html#mixins-cause-name-clashes) de nos erreurs.
 
 La proposition officielle pour les Hooks résout ce problème en utilisant plutôt l’ordre d’appel : même si deux Hooks utilisent une variable d’état `name`, elles seront isolées l’une de l’autre.  Chaque appel à `useState()` obtient sa propre « cellule mémoire ».
 
@@ -589,7 +589,7 @@ function createModal(React) {
 
 Mais en pratique, ça deviendrait juste une couche énervante d’indirection.  Le jour où on voudra effectivement remplacer React par autre chose, on pourra toujours plutôt le faire au niveau du systèmes de modules.
 
-C’est pareil pour les Hooks. Ceci dit, comme [la réponse de Sebastian](https://github.com/reactjs/rfcs/pull/68#issuecomment-439314884) le mentionne, il est *techniquement possible* de « rediriger » les Hooks exportés par `react` vers une autre implémentation. ([Un de mes précédents articles](/fr/how-does-setstate-know-what-to-do/) indique comment.)
+C’est pareil pour les Hooks. Ceci dit, comme [la réponse de Sebastian](https://github.com/reactjs/rfcs/pull/68#issuecomment-439314884) le mentionne, il est *techniquement possible* de « rediriger » les Hooks exportés par `react` vers une autre implémentation. ([Un de mes précédents articles](/how-does-setstate-know-what-to-do/) indique comment.)
 
 Une autre manière d’imposer trop de formalisme consisterait à rendre les Hooks [monadiques](https://paulgray.net/an-alternative-design-for-hooks/) ou à ajouter un concept à part entière du genre `React.createHook()`. Le surcoût d’exécution mis à part, toute solution qui ajoute de l’enrobage nous fait perdre un des avantages majeurs des fonctions nues : *y’a pas plus simple à déboguer.*
 
@@ -601,4 +601,4 @@ Comme je l’ai dit plus tôt, cet article n’ambitionne pas d’être exhausti
 
 Les Hooks ne sont pas non plus parfaits, mais ils constituent le meilleur compromis que nous avons pu trouver pour résoudre ces problèmes.  Il existe encore des choses que nous [devons régler](https://github.com/reactjs/rfcs/pull/68#issuecomment-440780509), et il y a des choses qui sont plus malaisées à faire avec les Hooks qu’avec des classes.  Là aussi, c’est un sujet pour un autre article.
 
-Que j’aie ou non couvert votre proposition alternative préférée, j’espère que ce texte vous aura aidés à mieux comprendre notre processus de réflexion et les critères que nous examinons quand nous choisissons une API.  Comme vous pouvez le voir, de nombreux points (tels que la capacité à copier-coller en confiance, à déplacer du code, à ajouter ou retirer des dépendances) servent à [optimiser pour le changement](/fr/optimized-for-change/).  J’espère que les utilisateurs de React apprécieront ces aspects.
+Que j’aie ou non couvert votre proposition alternative préférée, j’espère que ce texte vous aura aidés à mieux comprendre notre processus de réflexion et les critères que nous examinons quand nous choisissons une API.  Comme vous pouvez le voir, de nombreux points (tels que la capacité à copier-coller en confiance, à déplacer du code, à ajouter ou retirer des dépendances) servent à [optimiser pour le changement](/optimized-for-change/).  J’espère que les utilisateurs de React apprécieront ces aspects.

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -96,14 +96,33 @@ class BlogPostTemplate extends React.Component {
   render() {
     const post = this.props.data.markdownRemark;
     const siteTitle = get(this.props, 'data.site.siteMetadata.title');
-    const { previous, next, slug, translations } = this.props.pageContext;
+    let {
+      previous,
+      next,
+      slug,
+      translations,
+      translatedLinks,
+    } = this.props.pageContext;
     const lang = post.fields.langKey;
 
+    // Replace original links with translated when available.
+    let html = post.html;
+    translatedLinks.forEach(link => {
+      // jeez
+      function escapeRegExp(str) {
+        return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      }
+      let translatedLink = '/' + lang + link;
+      html = html.replace(new RegExp(escapeRegExp(link), 'g'), translatedLink);
+    });
+
+    translations = translations.slice();
     translations.sort((a, b) => {
       return codeToLanguage(a) < codeToLanguage(b) ? -1 : 1;
     });
 
     loadFontsForCode(lang);
+    // TODO: this curried function is annoying
     const languageLink = createLanguageLink(slug, lang);
     const enSlug = languageLink('en');
     const editUrl = `https://github.com/${GITHUB_USERNAME}/${GITHUB_REPO_NAME}/edit/master/src/pages/${enSlug.slice(
@@ -113,6 +132,7 @@ class BlogPostTemplate extends React.Component {
     const discussUrl = `https://mobile.twitter.com/search?q=${encodeURIComponent(
       `https://overreacted.io${enSlug}`
     )}`;
+
     return (
       <Layout location={this.props.location} title={siteTitle}>
         <SEO
@@ -147,7 +167,7 @@ class BlogPostTemplate extends React.Component {
                 />
               )}
             </header>
-            <div dangerouslySetInnerHTML={{ __html: post.html }} />
+            <div dangerouslySetInnerHTML={{ __html: html }} />
             <footer>
               <p>
                 <a href={discussUrl} target="_blank" rel="noopener noreferrer">

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -113,7 +113,10 @@ class BlogPostTemplate extends React.Component {
         return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
       }
       let translatedLink = '/' + lang + link;
-      html = html.replace(new RegExp(escapeRegExp(link), 'g'), translatedLink);
+      html = html.replace(
+        new RegExp('"' + escapeRegExp(link) + '"', 'g'),
+        '"' + translatedLink + '"'
+      );
     });
 
     translations = translations.slice();

--- a/src/utils/i18n.js
+++ b/src/utils/i18n.js
@@ -72,9 +72,10 @@ export const loadFontsForCode = code => {
   }
 };
 
+// TODO: the curried signature is weird.
 export const createLanguageLink = (slug, lang) => {
   const rawSlug = slug.replace(`${lang}/`, '');
 
   return targetLang =>
-    targetLang === 'en' ? rawSlug : `${targetLang}/${rawSlug}`;
+    targetLang === 'en' ? rawSlug : `${targetLang}${rawSlug}`;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5219,6 +5219,14 @@ gatsby-link@^2.0.8:
     "@types/reach__router" "^1.0.0"
     prop-types "^15.6.1"
 
+gatsby-plugin-catch-links@^2.0.9:
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-catch-links/-/gatsby-plugin-catch-links-2.0.9.tgz#1fd5bf02a7f997f7b36c4e0c28b689f0c3d92726"
+  integrity sha512-0I78VTwy9GJkh8nEt33VASo/cvBmDtdChoISQ+U0Pio5pXEXT2RQIesuHwcm4pXG/VRDVnEYxa95PLUccW5vFg==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    escape-string-regexp "^1.0.5"
+
 gatsby-plugin-feed@^2.0.8:
   version "2.0.11"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-feed/-/gatsby-plugin-feed-2.0.11.tgz#1baa33565c131415a2c971aa49adea02a08bf935"


### PR DESCRIPTION
Alternative to https://github.com/gaearon/overreacted.io/pull/143.
Should fix #141 and #101.

`gatsby-plugin-catch-links` takes care of linkifying internal posts. It actually seems to work pretty great out of the box and I didn't need to mess with it.

In order to automatically link translations, I'm gathering a list of what seems to be Markdown intra-domain links in `onCreateNode`. Then in `createPages` I do a pass to check if it looks like they're internal links that have translations. Translated pages receive an array of eligible hrefs in the page context. Finally, the post page does a pass over HTML to replace all links that we *know* have translations.

This shouldn't have much runtime or bundle size overhead. One post wouldn't pay for all translations I think. Only the linked ones from it.