### PR TITLE
Better scrolling behavior

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,0 +1,75 @@
+// gatsby-browser.js
+import React from 'react';
+
+// Forked Gatsby default to not remount on switches between
+// translated versions of the same page.
+export function replaceComponentRenderer({ props, loader }) {
+  return React.createElement(props.pageResources.component, {
+    ...props,
+
+    // Gatsby default is:
+    // key: props.pageResources.page.path,
+
+    // But we're happy with letting React do its thing.
+  });
+}
+
+function countSlashes(url) {
+  let n = 0;
+  for (let i = 0; i < url.length; i++) {
+    if (url[i] === '/') {
+      n++;
+    }
+  }
+  return n;
+}
+
+function shouldPreserveScrollBetween(oldPathname, newPathname) {
+  // Don't reset scroll when switching within a post.
+  // TODO: this is kinda gross and flaky.
+  if (
+    // /lang/stuff/ -> /stuff/
+    (oldPathname.indexOf(newPathname) > 0 &&
+      countSlashes(oldPathname) === 3 &&
+      countSlashes(newPathname) === 2) ||
+    // /stuff/ -> /lang/stuff/
+    (newPathname.indexOf(oldPathname) > 0 &&
+      countSlashes(oldPathname) === 2 &&
+      countSlashes(newPathname) === 3) ||
+    // /lang/stuff/ -> /other-lang/stuff/
+    (countSlashes(oldPathname) === 3 &&
+      countSlashes(newPathname) === 3 &&
+      // /stuff/ === /stuff/
+      oldPathname.substr(oldPathname.substr(1).indexOf('/') + 1) ===
+        newPathname.substr(newPathname.substr(1).indexOf('/') + 1))
+  ) {
+    return true;
+  }
+  return false;
+}
+
+// Forked to not update scroll on transitions between translations.
+// Sadness. I have to override a *plugin* because it already has its own logic,
+// and Gatsby just ignores mine, lol. TODO: fork this plugin?
+let oldShouldUpdateScroll = require('gatsby-remark-autolink-headers/gatsby-browser')
+  .shouldUpdateScroll;
+if (typeof oldShouldUpdateScroll !== 'function') {
+  throw new Error('No monkeypatching today :-(');
+}
+require('gatsby-remark-autolink-headers/gatsby-browser').shouldUpdateScroll = function shouldUpdateScroll({
+  prevRouterProps,
+  routerProps,
+}) {
+  const { pathname, hash } = routerProps.location;
+  if (prevRouterProps) {
+    const {
+      location: { pathname: oldPathname },
+    } = prevRouterProps;
+    if (shouldPreserveScrollBetween(oldPathname, pathname)) {
+      return false;
+    }
+  }
+  // Call it manually so we have a chance to preserve scroll the line before.
+  // TODO: maybe inline whatever it does.
+  return oldShouldUpdateScroll.apply(this, arguments);
+};

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "gatsby-plugin-react-helmet": "^3.0.0",
     "gatsby-plugin-sharp": "^2.0.16",
     "gatsby-plugin-typography": "^2.2.0",
-    "gatsby-remark-autolink-headers": "^2.0.12",
+    "gatsby-remark-autolink-headers": "2.0.12",
     "gatsby-remark-copy-linked-files": "^2.0.5",
     "gatsby-remark-images": "^2.0.6",
     "gatsby-remark-prismjs": "^3.0.0",

--- a/src/utils/typography.js
+++ b/src/utils/typography.js
@@ -14,8 +14,12 @@ Wordpress2016.overrideThemeStyles = () => ({
   'a.gatsby-resp-image-link': {
     boxShadow: 'none',
   },
+  // These two are for gatsby-remark-autolink-headers:
   'a.anchor': {
     boxShadow: 'none',
+  },
+  'a.anchor svg[aria-hidden="true"]': {
+    stroke: 'var(--textLink)',
   },
   'p code': {
     fontSize: '1rem',


### PR DESCRIPTION
1. Switching between translations of the same article doesn't jump the scroll anymore. (It also means going back and forth preserves scroll position which might be weird but IMO it's okay.)
2. Also fixes https://github.com/gaearon/overreacted.io/issues/195