### PR TITLE
Fixes RSS feed lacking post dates

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -88,7 +88,7 @@ module.exports = {
 
                 return Object.assign({}, edge.node.frontmatter, {
                   description: edge.node.frontmatter.spoiler,
-                  date: edge.node.fields.date,
+                  date: edge.node.frontmatter.date,
                   url: site.siteMetadata.siteUrl + edge.node.fields.slug,
                   guid: site.siteMetadata.siteUrl + edge.node.fields.slug,
                   custom_elements: [{ 'content:encoded': html + postText }],


### PR DESCRIPTION
So I decided to play with a different RSS reader and I imported a few of the feeds that I'm subscribed to in the RSS application I normally use, and I noticed something... special about the RSS feed for overreacted.io:

![List of recent blog posts in overreacted.io](https://user-images.githubusercontent.com/1568690/52012821-dd416900-24db-11e9-95bd-98a7a10453ad.png)

After looking at the XML file for the RSS feed at https://overreacted.io/rss.xml I noticed that the posts lack the `<pubDate>` tag, so my RSS reader doesn't know at which date and time is the blog post published, therefore having an undefined behaviour.

This PR updates the serializer method used by gatsby-plugin-feed to fix this, as it seems that it is accessing the wrong variable when looking up for the publication date in the given query.