### PR TITLE
Code block edits: JSX syntax highlighting, negative margins

### DIFF
--- a/src/pages/how-does-setstate-know-what-to-do/index.fr.md
+++ b/src/pages/how-does-setstate-know-what-to-do/index.fr.md
@@ -78,7 +78,7 @@ Le point à retenir ici, c’est que le module `react` vous permet seulement d�
 
 Mais `React.createContext()` *n’implémente* pas vraiment la fonctionnalité de contexte. L’implémentation va différer par exemple entre React DOM et React DOM Server. Du coup, `createContext()` ne renvoie que quelques objets nus :
 
-```js
+```jsx
 // Un peu simplifié
 function createContext(defaultValue) {
   let context = {
@@ -110,7 +110,7 @@ Bon, donc on sait maintenant que le module `react` ne contient rien de bien int�
 
 **Il s’avère que chaque moteur définit un champ spécial sur la classe créée.** Ce champ est appelée `updater`.  Ce n’est pas quelque chose que *vous* définiriez—c’est plutôt un champ défini par React DOM, React DOM Server ou React Native juste après avoir instancié votre classe :
 
-```js{4,9,14}
+```jsx{4,9,14}
 // Dans React DOM
 const inst = new YourComponent();
 inst.props = props;
@@ -129,7 +129,7 @@ inst.updater = ReactNativeUpdater;
 
 Si on regarde [l’implémentation de `setState` dans `React.Component`](https://github.com/facebook/react/blob/ce43a8cd07c355647922480977b46713bd51883e/packages/react/src/ReactBaseClasses.js#L58-L67), elle se contente de déléguer le boulot au moteur qui a instancié le composant :
 
-```js
+```jsx
 // Un peu simplifié
 setState(partialState, callback) {
   // Utilise le champ `updater` pour parler au moteur !
@@ -152,7 +152,7 @@ Mais comme nous venons de le voir, l’implémentation de `setState()` dans cett
 
 **Au lieu du champ `updater`, les Hooks utilisent un objet « envoyeur ».** Quand vous appelez `React.useState()`, `React.useEffect()`, ou n’importe quel autre Hook prédéfini, ces appels sont transférés à l’envoyeur courant.
 
-```js
+```jsx
 // Dans React (un peu simplifié)
 const React = {
   // La véritable propriété est en fait enfouie plus profondément,
@@ -172,7 +172,7 @@ const React = {
 
 Et les différents moteurs définissent l’envoyeur avant d’assurer le rendu du composant :
 
-```js{3,8-9}
+```jsx{3,8-9}
 // Dans React DOM
 const prevDispatcher = React.__currentDispatcher;
 React.__currentDispatcher = ReactDOMDispatcher;

--- a/src/pages/how-does-setstate-know-what-to-do/index.ja.md
+++ b/src/pages/how-does-setstate-know-what-to-do/index.ja.md
@@ -83,7 +83,7 @@ Reactの「エンジン」は `react`パッケージの中にあるという一�
 
 しかし `React.createContext()`は実際にはコンテキスト機能を実装していません。 たとえば、React DOMとReact DOM Serverでは実装が異なる必要があります。 そのため `createContext()`はいくつかのプレーンなオブジェクトを返します。:
 
-```js
+```jsx
 // 少し簡略化しています
 function createContext(defaultValue) {
   let context = {
@@ -119,7 +119,7 @@ React DOMはある方法でコンテキスト値を追跡するかもしれま�
 それはあなたが設定するものではありません - むしろ、それはあなたのクラスのインスタンスを作成した直後にReact React DOM ServerまたはReact Nativeがセットするものです：
 
 
-```js{4,9,14}
+```jsx{4,9,14}
 // React DOM 内部
 const inst = new YourComponent();
 inst.props = props;
@@ -138,7 +138,7 @@ inst.updater = ReactNativeUpdater;
 
 [`React.Component`の`setState`の実装](https://github.com/facebook/react/blob/ce43a8cd07c355647922480977b46713bd51883e/packages/react/src/ReactBaseClasses.js#L58-L67)を見てください。このコンポーネントインスタンスを作成したレンダラーに作業を委任するだけです。
 
-```js
+```jsx
 // 少し簡略化しています
 setState(partialState, callback) {
   // レンダラーと「対話」するには `updater`フィールドを使って!
@@ -162,7 +162,7 @@ React DOMサーバーは状態の更新を無視して[警告しようとする�
 
 **`updater`フィールドの代わりに、フックは"dispatcher"オブジェクトを使います。** `React.useState()`,`React.useEffect()`あるいは他の組み込みHookを呼び出すと、これらの呼び出しは現在のディスパッチャに転送されます。
 
-```js
+```jsx
 // React内 (少し簡略化しています)
 const React = {
   // 本当のプロパティはもう少し深くに隠されています。見つけられたら見てください！
@@ -181,7 +181,7 @@ const React = {
 
 そして個々のレンダラーはコンポーネントをレンダリングする前にディスパッチャーを設定します：
 
-```js{3,8-9}
+```jsx{3,8-9}
 // React DOM内
 const prevDispatcher = React.__currentDispatcher;
 React.__currentDispatcher = ReactDOMDispatcher;

--- a/src/pages/how-does-setstate-know-what-to-do/index.md
+++ b/src/pages/how-does-setstate-know-what-to-do/index.md
@@ -78,7 +78,7 @@ Now we know why *both* `react` and `react-dom` packages need to be updated for n
 
 But `React.createContext()` doesn’t actually *implement* the context feature. The implementation would need to be different between React DOM and React DOM Server, for example. So `createContext()` returns a few plain objects:
 
-```js
+```jsx
 // A bit simplified
 function createContext(defaultValue) {
   let context = {
@@ -111,7 +111,7 @@ Okay, so now we know that the `react` package doesn’t contain anything interes
 **The answer is that every renderer sets a special field on the created class.** This field is called `updater`. It’s not something *you* would set — rather, it’s something React DOM, React DOM Server or React Native set right after creating an instance of your class:
 
 
-```js{4,9,14}
+```jsx{4,9,14}
 // Inside React DOM
 const inst = new YourComponent();
 inst.props = props;
@@ -130,7 +130,7 @@ inst.updater = ReactNativeUpdater;
 
 Looking at the [`setState` implementation in `React.Component`](https://github.com/facebook/react/blob/ce43a8cd07c355647922480977b46713bd51883e/packages/react/src/ReactBaseClasses.js#L58-L67), all it does is delegate work to the renderer that created this component instance:
 
-```js
+```jsx
 // A bit simplified
 setState(partialState, callback) {
   // Use the `updater` field to talk back to the renderer!
@@ -152,7 +152,7 @@ But as we have seen today, the base class `setState()` implementation has been a
 
 **Instead of an `updater` field, Hooks use a “dispatcher” object.** When you call `React.useState()`, `React.useEffect()`, or another built-in Hook, these calls are forwarded to the current dispatcher.
 
-```js
+```jsx
 // In React (simplified a bit)
 const React = {
   // Real property is hidden a bit deeper, see if you can find it!
@@ -171,7 +171,7 @@ const React = {
 
 And individual renderers set the dispatcher before rendering your component:
 
-```js{3,8-9}
+```jsx{3,8-9}
 // In React DOM
 const prevDispatcher = React.__currentDispatcher;
 React.__currentDispatcher = ReactDOMDispatcher;

--- a/src/pages/the-bug-o-notation/index.md
+++ b/src/pages/the-bug-o-notation/index.md
@@ -31,7 +31,7 @@ The Big-O describes how much an algorithm slows down as the inputs grow. The *Bu
 
 For example, consider this code that manually updates the DOM over time with imperative operations like `node.appendChild()` and `node.removeChild()` and no clear structure:
 
-```js
+```jsx
 function trySubmit() {
   // Section 1
   let spinner = createSpinner();
@@ -70,7 +70,7 @@ This function has 4 different sections and no guarantees about their ordering. M
 
 To improve the Bug-O of this code, we can limit the number of possible states and outcomes. We don't need any library to do this. It’s just a matter of enforcing some structure on our code. Here is one way we could do it:
 
-```js
+```jsx
 let currentState = {
   step: 'initial', // 'initial' | 'pending' | 'success' | 'error'
 };
@@ -116,7 +116,7 @@ function setState(nextState) {
 
 This code might not look too different. It’s even a bit more verbose. But it is *dramatically* simpler to debug because of this line:
 
-```js{3}
+```jsx{3}
 function setState(nextState) {
   // Clear all existing children
   formStatus.innerHTML = '';
@@ -130,7 +130,7 @@ By clearing out the form status before doing any manipulations, we ensure that o
 
 We might still have race conditions in *setting* the state, but debugging those is easier because each intermediate state can be logged and inspected. We can also disallow any undesired transitions explicitly:
 
-```js
+```jsx
 function trySubmit() {
   if (currentState.step === 'pending') {
     // Don't allow to submit twice
@@ -142,7 +142,7 @@ Of course, always resetting the DOM comes with a tradeoff. Naïvely removing and
 
 That’s why libraries like React can be helpful. They let you *think* in the paradigm of always recreating the UI from scratch without necessarily doing it:
 
-```js
+```jsx
 function FormStatus() {
   let [state, setState] = useState({
     step: 'initial'

--- a/src/pages/why-do-hooks-rely-on-call-order/index.fr.md
+++ b/src/pages/why-do-hooks-rely-on-call-order/index.fr.md
@@ -357,7 +357,7 @@ Cette approche est plutôt lourde.  Un des objectifs de conception des Hooks ét
 
 Qui plus est, on devrait répéter chaque Hook personnalisé utilisé par un composant : une première fois au niveau racine (ou dans la portée de la fonction si on écrit un Hook personnalisé), et une seconde fois à l’emplacement effectif d’appel.  Ça signifie qu’il vous faudrait jongler entre le rendu et la déclaration racine même pour de petites modifications :
 
-```js{2,3,7,8}
+```jsx{2,3,7,8}
 // ⚠️ Ceci n’est PAS l’API de Hooks de React
 const useNameFormInput = createUseFormInput();
 const useSurnameFormInput = createUseFormInput();
@@ -374,7 +374,7 @@ Il faudrait aussi faire preuve de beaucoup de rigueur dans le nommage.  On aurai
 
 Si vous appeliez la même « instance » de Hook personnalisé deux fois, vous auriez un conflit d’état.  En fait, le code ci-dessus fait cette erreur, vous l’aviez remarqué ? Ce devrait être :
 
-```js
+```jsx
   const name = useNameFormInput();
   const surname = useSurnameFormInput(); // Et non useNameFormInput !
 ```
@@ -389,7 +389,7 @@ Il existe une autre façon d’éviter les conflits dus à un état géré par c
 
 L’idée serait de *composer* les clés chaque fois qu’on écrit un Hook personnalisé.  Quelque chose comme ça :
 
-```js{4,5,16,17}
+```jsx{4,5,16,17}
 // ⚠️ Ceci n’est PAS l’API de Hooks de React
 function Form() {
   // ...
@@ -426,7 +426,7 @@ Devoir se rappeler de passer des clés à travers chaque couche de Hooks personn
 
 Selon vous, que signifie le code ci-dessous ?
 
-```js{3,4}
+```jsx{3,4}
 // ⚠️ Ceci n’est PAS l’API de Hooks de React
 function Counter(props) {
   if (props.isActive) {
@@ -445,7 +445,7 @@ Est-ce que `count` est préservé quand `props.isActive` est `false` ?  Ou alor
 
 Si un état conditionnel est préservé, qu’en est-il d’un effet ?
 
-```js{5-8}
+```jsx{5-8}
 // ⚠️ Ceci n’est PAS l’API de Hooks de React
 function Counter(props) {
   if (props.isActive) {
@@ -535,14 +535,14 @@ Quand on change le destinataire, notre Hook `useFriendStatus()` serait automatiq
 
 Ça fonctionne parce qu’on peut passer la valeur de retour du Hook `useState()` au Hook `useFriendStatus()` :
 
-```js{2}
+```jsx{2}
   const [recipientID, setRecipientID] = useState(1);
   const isRecipientOnline = useFriendStatus(recipientID);
 ```
 
 Passer des valeurs entre les Hooks recèle une énorme puissance.  Par exemple, [React Spring](https://medium.com/@drcmda/hooks-in-react-spring-a-tutorial-c6c436ad7ee4) vous permet de créer une séquence d’animations basée sur plusieurs valeurs qui se « suivent » l’une l’autre :
 
-```js
+```jsx
   const [{ pos1 }, set] = useSpring({ pos1: [0, 0], config: fast });
   const [{ pos2 }] = useSpring({ pos2: pos1, config: slow });
   const [{ pos3 }] = useSpring({ pos3: pos2, config: slow });
@@ -564,7 +564,7 @@ Je trouve que [la réponse de Sebastian](https://github.com/reactjs/rfcs/pull/68
 
 Je me contenterai de dire ici que ce n’est pas sans raison que les programmeurs ont tendance à préférer `try` / `catch` plutôt que passer les codes d’erreur à travers chaque fonction de rappel lorsqu’il s’agit de gérer les erreurs. C’est pour la même raison qu’ils préfèrent les modules ES basés sur `import` (ou le `require` de CommonJS) aux définitions « explicites » d’AMD qui nous passent le `require` en argument.
 
-```js
+```jsx
 // Y’a-t-il quelqu’un qui est nostalgique d’AMD ?
 define(['require', 'dependency1', 'dependency2'], function (require) {
   var dependency1 = require('dependency1');
@@ -579,7 +579,7 @@ Oui, AMD est peut-être plus « honnête » sur le fait que les modules ne son
 
 C’est un peu comme le fait que, lorsqu’on définit des composants, on choppe juste le `Component` depuis `React`.  Notre code serait sans doute plus découplé de React si on exportait à la place une factory pour chaque composant :
 
-```js
+```jsx
 function createModal(React) {
   return class Modal extends React.Component {
     // ...

--- a/src/pages/why-do-hooks-rely-on-call-order/index.md
+++ b/src/pages/why-do-hooks-rely-on-call-order/index.md
@@ -353,7 +353,7 @@ This approach is rather heavy-handed. One of the design goals of Hooks is to avo
 
 Additionally, you have to repeat every custom Hook used in a component twice. Once in the top level scope (or inside a function scope if we’re writing a custom Hook), and once at the actual call site. This means you have to jump between the rendering and top-level declarations even for small changes:
 
-```js{2,3,7,8}
+```jsx{2,3,7,8}
 // ⚠️ This is NOT the React Hooks API
 const useNameFormInput = createUseFormInput();
 const useSurnameFormInput = createUseFormInput();
@@ -370,7 +370,7 @@ You also need to be very precise with their names. You would always have “two 
 
 If you call the same custom Hook “instance” twice you’d get a state clash. In fact, the code above has this mistake — have you noticed? It should be:
 
-```js
+```jsx
   const name = useNameFormInput();
   const surname = useSurnameFormInput(); // Not useNameFormInput!
 ```
@@ -385,7 +385,7 @@ There is another way to avoid conflicts with keyed state. If you know about it, 
 
 The idea is that we could *compose* keys every time we write a custom Hook. Something like this:
 
-```js{4,5,16,17}
+```jsx{4,5,16,17}
 // ⚠️ This is NOT the React Hooks API
 function Form() {
   // ...
@@ -422,7 +422,7 @@ This might make sense if conditionally declaring state and effects was very desi
 
 What does this code mean exactly?
 
-```js{3,4}
+```jsx{3,4}
 // ⚠️ This is NOT the React Hooks API
 function Counter(props) {
   if (props.isActive) {
@@ -441,7 +441,7 @@ Is `count` preserved when `props.isActive` is `false`? Or does it get reset beca
 
 If conditional state gets preserved, what about an effect?
 
-```js{5-8}
+```jsx{5-8}
 // ⚠️ This is NOT the React Hooks API
 function Counter(props) {
   if (props.isActive) {
@@ -531,14 +531,14 @@ When you change the recipient, our `useFriendStatus()` Hook would unsubscribe fr
 
 This works because we can pass the return value of the `useState()` Hook to the `useFriendStatus()` Hook:
 
-```js{2}
+```jsx{2}
   const [recipientID, setRecipientID] = useState(1);
   const isRecipientOnline = useFriendStatus(recipientID);
 ```
 
 Passing values between Hooks is very powerful. For example, [React Spring](https://medium.com/@drcmda/hooks-in-react-spring-a-tutorial-c6c436ad7ee4) lets you create a trailing animation of several values “following” each other:
 
-```js
+```jsx
   const [{ pos1 }, set] = useSpring({ pos1: [0, 0], config: fast });
   const [{ pos2 }] = useSpring({ pos2: pos1, config: slow });
   const [{ pos3 }] = useSpring({ pos3: pos2, config: slow });
@@ -560,7 +560,7 @@ I think [Sebastian’s answer](https://github.com/reactjs/rfcs/pull/68#issuecomm
 
 I’ll just say there is a reason programmers tend to prefer `try` / `catch` for error handling to passing error codes through every function. It’s the same reason why we prefer ES Modules with `import` (or CommonJS `require`) to AMD’s “explicit” definitions where `require` is passed to us.
 
-```js
+```jsx
 // Anyone miss AMD?
 define(['require', 'dependency1', 'dependency2'], function (require) {
   var dependency1 = require('dependency1'),
@@ -575,7 +575,7 @@ Yes, AMD may be more “honest” to the fact that modules aren’t actually syn
 
 This is similar to how, when we define components, we just grab `Component` from `React`. Maybe our code would be more decoupled from React if we exported a factory for every component instead:
 
-```js
+```jsx
 function createModal(React) {
   return class Modal extends React.Component {
     // ...

--- a/src/pages/why-do-we-write-super-props/index.tr.md
+++ b/src/pages/why-do-we-write-super-props/index.tr.md
@@ -14,7 +14,7 @@ Duyduğuma göre [Hooks](https://reactjs.org/docs/hooks-intro.html) en çok konu
 
 Hayatımda `super(props)`u bilmek istediğimden çok daha fazla yazdım:
 
-```js{3}
+```jsx{3}
 class Checkbox extends React.Component {
   constructor(props) {
     super(props);
@@ -26,7 +26,7 @@ class Checkbox extends React.Component {
 
 Tabi ki, [class fields önerisi](https://github.com/tc39/proposal-class-fields) tüm bu seremoniyi atlamamızı sağlıyor:
 
-```js
+```jsx
 class Checkbox extends React.Component {
   state = { isOn: true };
   // ...
@@ -37,7 +37,7 @@ class Checkbox extends React.Component {
 
 Ama sadece ES2015 özelliklerini kullanan bu örneğe tekrar dönelim:
 
-```js{3}
+```jsx{3}
 class Checkbox extends React.Component {
   constructor(props) {
     super(props);
@@ -55,7 +55,7 @@ JavaScript dilinde, `super` ebeveyn class constructor'a işaret eder. (Bizim ör
 
 Önemle, bir constructor içerisinde, ebeveyn constructor'ını çağırana kadar, `this`'i kullanamazsınız. JavaScript izin vermez:
 
-```js
+```jsx
 class Checkbox extends React.Component {
   constructor(props) {
     // 🔴 Henüz `this` kullanamazsın
@@ -69,7 +69,7 @@ class Checkbox extends React.Component {
 
 JavaScript'in, `this`'e dokunmadan önce ebeveyn constructor'ın çalışmasına zorlamasının iyi bir nedeni var. Class hiyerarşisini düşünün:
 
-```js
+```jsx
 class Person {
   constructor(name) {
     this.name = name;
@@ -89,7 +89,7 @@ class PolitePerson extends Person {
 
 `super` fonksiyonunu çağırmadan `this` *kullanabildiğimizi* düşünün. Bir ay sonra, `greetColleagues` fonksiyonunu, kişinin ismini parametre olarak alacak şekilde değiştirebiliriz:
 
-```js
+```jsx
   greetColleagues() {
     alert('Günaydın gençler!');
     alert('Benim adım ' + this.name + ', tanıştığıma memnun oldum!');
@@ -100,7 +100,7 @@ Ancak `this.greetColleagues()` fonksiyonunun, daha `super()` fonksiyonunun `this
 
 Bunun gibi sıkıntılardan kurtulmak için, **JavaScript; "eğer constructor içinde `this` kullanmak istiyorsan, önce `super` çağırmak *zorundasın*" diyor.** Ebeveyni bir bırak, işini halletsin! Ve bu sınırlama aynı şekilde class olarak tanımlanmış React componentleri'ne de uygulanıyor:
 
-```js
+```jsx
   constructor(props) {
     super(props);
     // ✅ Buradan sonra `this` kullanabilirsin
@@ -114,7 +114,7 @@ Bu bizi başka bir soruya yöneltiyor: neden `props`'u göndermeliyiz?
 
 `super` fonksiyonuna `props` argümanını göndermem gerekiyor ki `React.Component`'in constructor fonksiyonu `this.props`'u oluşturabilsin diye düşünebilirsiniz:
 
-```js
+```jsx
 // Inside React
 class Component {
   constructor(props) {
@@ -130,7 +130,7 @@ Ama nedense, `super()` fonksiyonunu `props` göndermeden çağırsanız bile, `r
 
 Peki *bu* nasıl çalışıyor? Meğerse **React *sizin* constructor fonksiyonunuzdan hemen sonra, `props` parametresini kendi atıyor:**
 
-```js
+```jsx
   // React'ın içi
   const instance = new YourComponent(props);
   instance.props = props;
@@ -144,7 +144,7 @@ Peki bu `super(props)` yerine sadece `super()` yazabileceğiniz anlamına mı ge
 
 **Büyük ihtimalle hayır çünkü hala biraz kafa karıştırıcı.** Tabi ki, React zaten `this.props` değerini sizin constructor'ınız çalıştıktan *sonra* atayacaktır. Ancak `this.props` değeri, `super` fonksiyonunu çağırma satırı ve constructor'ınızın sonu *arasında* tanımlanmamış olacaktır.
 
-```js{14}
+```jsx{14}
 // React'ın içi
 class Component {
   constructor(props) {
@@ -166,7 +166,7 @@ class Button extends React.Component {
 
 Bu, eğer constructor'ın *içinde* çağrılan bir metod içinde olursa, debug yapmak daha da zorlaşacaktır. **Ve işte tam olarak bu yüzden, zorunlu olmamasına rağmen, her zaman `super(props)` olarak kullanmayı öneriyorum:**
 
-```js
+```jsx
 class Button extends React.Component {
   constructor(props) {
     super(props); // ✅ props'u gönderdik

--- a/src/pages/why-isnt-x-a-hook/index.es.md
+++ b/src/pages/why-isnt-x-a-hook/index.es.md
@@ -34,7 +34,7 @@ Estas dos restricciones juntas nos pueden decir qué puede o *no puede* ser un H
 
 Múltiples Hooks personalizados invocando cada uno a `useState()` no entran en conflicto:
 
-```js
+```jsx
 function useMyCustomHook1() {
   const [value, setValue] = useState(0);
   // Lo que pasa aquí, aquí se queda.
@@ -60,7 +60,7 @@ Añadir una nueva invocación incondicional a `useState()` es siempre segura. No
 
 Los Hooks son útiles porque puedes pasar valores *entre* ellos:
 
-```js{4,12,14}
+```jsx{4,12,14}
 function useWindowWidth() {
   const [width, setWidth] = useState(window.innerWidth);
   // ...
@@ -107,7 +107,7 @@ Una forma de hacerlo es cubrir todo el componente con[`React.memo()`](https://re
 
 `React.memo()` toma un componente y devuelve un componente:
 
-```js{4}
+```jsx{4}
 function Button(props) {
   // ...
 }
@@ -118,7 +118,7 @@ export default React.memo(Button);
 
 Ya sea si lo llamas `useShouldComponentUpdate()`, `useBailout()`, `usePure()`, o `useShouldComponentUpdate()`, la propuesta suele parecerse a algo como esto:
 
-```js
+```jsx
 function Button({ color }) {
   // ⚠️ No es una API real
   useBailout(prevColor => prevColor !== color, color);
@@ -137,7 +137,7 @@ Hay algunas otras variaciones (por ejemplo un simple marcador `usePure()`) pero 
 
 Digamos que intentamos poner `useBailout()` en dos Hooks personalizados:
 
-```js{4,5,19,20}
+```jsx{4,5,19,20}
 function useFriendStatus(friendID) {
   const [isOnline, setIsOnline] = useState(null);
 
@@ -172,7 +172,7 @@ function useWindowWidth() {
 ¿Qué ocurre ahora si usas ambos en el mismo componente?
 
 
-```js{2,3}
+```jsx{2,3}
 function ChatThread({ friendID, isTyping }) {
   const width = useWindowWidth();
   const isOnline = useFriendStatus(friendID);
@@ -201,7 +201,7 @@ Aún peor, con estas semánticas **cualquier Hook que se añada a `ChatThread` s
 
 Utilizaremos el mismo ejemplo:
 
-```js
+```jsx
 function ChatThread({ friendID, isTyping }) {
   const width = useWindowWidth();
   const isOnline = useFriendStatus(friendID);

--- a/src/pages/why-isnt-x-a-hook/index.md
+++ b/src/pages/why-isnt-x-a-hook/index.md
@@ -34,7 +34,7 @@ These two constraints put together can tell us what can or *cannot* be a Hook. L
 
 Multiple custom Hooks each calling `useState()` don’t conflict:
 
-```js
+```jsx
 function useMyCustomHook1() {
   const [value, setValue] = useState(0);
   // What happens here, stays here.
@@ -60,7 +60,7 @@ Adding a new unconditional `useState()` call is always safe. You don’t need to
 
 Hooks are useful because you can pass values *between* Hooks:
 
-```js{4,12,14}
+```jsx{4,12,14}
 function useWindowWidth() {
   const [width, setWidth] = useState(window.innerWidth);
   // ...
@@ -107,7 +107,7 @@ One way to do it is to put a [`React.memo()`](https://reactjs.org/blog/2018/10/2
 
 `React.memo()` takes a component and returns a component:
 
-```js{4}
+```jsx{4}
 function Button(props) {
   // ...
 }
@@ -118,7 +118,7 @@ export default React.memo(Button);
 
 Whether you call it `useShouldComponentUpdate()`, `usePure()`, `useSkipRender()`, or `useBailout()`, the proposal tends to look something like this:
 
-```js
+```jsx
 function Button({ color }) {
   // ⚠️ Not a real API
   useBailout(prevColor => prevColor !== color, color);
@@ -137,7 +137,7 @@ There are a few more variations (e.g. a simple `usePure()` marker) but in broad 
 
 Let’s say we try to put `useBailout()` in two custom Hooks:
 
-```js{4,5,19,20}
+```jsx{4,5,19,20}
 function useFriendStatus(friendID) {
   const [isOnline, setIsOnline] = useState(null);
 
@@ -172,7 +172,7 @@ function useWindowWidth() {
 Now what happens if you use them both in the same component?
 
 
-```js{2,3}
+```jsx{2,3}
 function ChatThread({ friendID, isTyping }) {
   const width = useWindowWidth();
   const isOnline = useFriendStatus(friendID);
@@ -201,7 +201,7 @@ How does a Hook like `useBailout()` affect debugging?
 
 We’ll use the same example:
 
-```js
+```jsx
 function ChatThread({ friendID, isTyping }) {
   const width = useWindowWidth();
   const isOnline = useFriendStatus(friendID);

--- a/src/utils/global.css
+++ b/src/utils/global.css
@@ -57,7 +57,7 @@ pre[class*='language-'] {
 /* Code blocks */
 pre[class*='language-'] {
   overflow: auto;
-  padding: 1em;
+  padding: 1.3125rem;
 }
 
 pre[class*='language-']::-moz-selection {
@@ -98,7 +98,7 @@ pre[class*='language-'] ::selection {
 }
 
 .token.comment {
-  color: rgb(99, 119, 119);
+  color: rgb(138, 151, 178);
 }
 
 .token.string,
@@ -161,8 +161,8 @@ pre[data-line] {
 .gatsby-highlight-code-line {
   background-color: hsla(207, 95%, 15%, 1);
   display: block;
-  margin-right: -1em;
-  margin-left: -1em;
+  margin-right: -1.3125rem;
+  margin-left: -1.3125rem;
   padding-right: 1em;
   padding-left: 0.75em;
   border-left: 0.25em solid #ffa7c4;
@@ -170,6 +170,8 @@ pre[data-line] {
 
 .gatsby-highlight {
   margin-bottom: 1.75rem;
+  margin-left: -1.3125rem;
+  margin-right: -1.3125rem;
   border-radius: 10px;
   background: #011627;
   -webkit-overflow-scrolling: touch;

--- a/src/utils/global.css
+++ b/src/utils/global.css
@@ -98,7 +98,7 @@ pre[class*='language-'] ::selection {
 }
 
 .token.comment {
-  color: rgb(138, 151, 178);
+  color: rgb(128, 147, 147);
 }
 
 .token.string,

--- a/src/utils/global.css
+++ b/src/utils/global.css
@@ -178,6 +178,12 @@ pre[data-line] {
   overflow: auto;
 }
 
+@media (max-width: 672px) {
+  .gatsby-highlight {
+    border-radius: 0;
+  }
+}
+
 .gatsby-highlight pre[class*='language-'] {
   float: left;
   min-width: 100%;


### PR DESCRIPTION
Changing from #200, separate branch

- Changes every instance of `js` to `jsx` for correct syntax highlighting

- Uses negative margin technique as seen on the React docs which makes the code align with the main blog text. On mobile, the block lies flush with the edge of the document which leaves more room for the code, resulting in less horizontal scrolling

### Before

![img](https://camo.githubusercontent.com/d2e2acf3043babbc5e9224977052875885a644f2/68747470733a2f2f692e6779617a6f2e636f6d2f38623335323265313336336536646536373535363838646138633664356130302e706e67)
<img src="https://i.gyazo.com/af708f12c342918d815f451a16ebad85.png" height="500">

### After

![img](https://i.gyazo.com/97a4c2fe00e7d2c6c66eeef75ebbcade.png)
<img src="https://i.gyazo.com/3784f210cb0b6fd3921379f39ca2c336.png" height="500">
