### PR TITLE
use array of children in example

### DIFF
--- a/src/pages/react-as-a-ui-runtime/index.md
+++ b/src/pages/react-as-a-ui-runtime/index.md
@@ -630,7 +630,7 @@ function Page({ currentUser, children }) {
 }
 ```
 
-*(`<A><B /></A>` in JSX is the same as `<A children={<B />} />`.)*
+*(`<A><B /></A>` in JSX is the same as `<A children={[<B />]} />`.)*
 
 But what if it has an early exit condition?
 


### PR DESCRIPTION
I might be wrong but I would’ve thought that in this example the "children" should be an array? Although even as I’m writing this and referencing some other bits you wrote in there I’m more thinking I might be wrong and actually you can just pass a single node as "children".

Anyways, if it applies, here you go, if not feel free to close it and I’ll assume the latter is the case.

Really great post as well, it taught me a lot.