### PR TITLE
Add support to build on now, deploy and alias

### DIFF
--- a/.nowignore
+++ b/.nowignore
@@ -1,0 +1,3 @@
+.cache
+public
+node_modules

--- a/now.json
+++ b/now.json
@@ -18,5 +18,9 @@
       "dest": "/$1",
       "headers": { "cache-control": "public, max-age=0, must-revalidate" }
     }
+  ],
+  "alias": "overreacted.io",
+  "builds": [
+    { "use": "@now/static-build", "src": "package.json", "config": { "distDir": "public" } }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "develop": "gatsby develop",
     "start": "npm run develop",
     "build": "rm -rf public && rm -rf .cache && gatsby build",
+    "now-build": "gatsby build",
     "deploy": "yarn build && cp now.json public/ && cd public && now alias $(now) overreacted.io",
     "dry": "yarn build && cp now.json public/ && cd public && now"
   },


### PR DESCRIPTION
This PR adds support to build this app inside Now and alias for each and every commit on master.
I test this on my own fork and [worked](https://github.com/arunoda/overreacted.io/commits/master) [well](https://github.com/arunoda/overreacted.io/commit/a80495f8463c49dac3bd3b90044da2dcafdd59f5#comments).

You'd also need to enable GitHub integration into your account.
For that, visit https://zeit.co/github

Ping me if you need additional info or changes.
