### PR TITLE
Add default return for the reducer example.

### DIFF
--- a/src/pages/react-as-a-ui-runtime/index.md
+++ b/src/pages/react-as-a-ui-runtime/index.md
@@ -848,6 +848,8 @@ When state logic gets more complex than a few `setState` calls, I recommend to e
   const [counter, dispatch] = useReducer((state, action) => {
     if (action === 'increment') {
       return state + 1;
+    } else {
+      return state;
     }
   }, 0);
 


### PR DESCRIPTION
Hey Dan!

I was confused for a bit when saw original example — does `useReducer` preserve the state if `undefined` is returned? 

It doesn't, so having explicit default case is important and will prevent this confusion.
