### PR TITLE
Add top level error boundary

### DIFF
--- a/src/components/ErrorBoundary.js
+++ b/src/components/ErrorBoundary.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-class Layout extends React.Component {
+class ErrorBoundary extends React.Component {
   state = {
     error: null,
   };
@@ -30,4 +30,4 @@ class Layout extends React.Component {
   }
 }
 
-export default Layout;
+export default ErrorBoundary;

--- a/src/components/ErrorBoundary.js
+++ b/src/components/ErrorBoundary.js
@@ -1,0 +1,33 @@
+import React from 'react';
+
+class Layout extends React.Component {
+  state = {
+    error: null,
+  };
+
+  static getDerivedStateFromError(error) {
+    return { error };
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div style={{ maxWidth: 310 }}>
+          An unexpected error has occurred:
+          <pre>{this.state.error.message}</pre>
+          <a
+            href="https://github.com/gaearon/overreacted.io/issues"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Please file an issue here
+          </a>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default Layout;

--- a/src/html.js
+++ b/src/html.js
@@ -6,18 +6,15 @@ import ErrorBoundary from './components/ErrorBoundary';
 export default class HTML extends React.Component {
   render() {
     return (
-      <ErrorBoundary>
-        <html {...this.props.htmlAttributes}>
-          <head>
-            <meta charSet="utf-8" />
-            <meta httpEquiv="x-ua-compatible" content="ie=edge" />
-            <meta
-              name="viewport"
-              content="width=device-width, initial-scale=1, shrink-to-fit=no"
-            />
-            {this.props.headComponents}
-          </head>
-          <body {...this.props.bodyAttributes} className="light">
+      <html {...this.props.htmlAttributes}>
+        <head>
+          <meta charSet="utf-8" />
+          <meta httpEquiv="x-ua-compatible" content="ie=edge" />
+          <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+          {this.props.headComponents}
+        </head>
+        <body {...this.props.bodyAttributes} className="light">
+          <ErrorBoundary>
             <script
               dangerouslySetInnerHTML={{
                 __html: `
@@ -59,9 +56,9 @@ export default class HTML extends React.Component {
               dangerouslySetInnerHTML={{ __html: this.props.body }}
             />
             {this.props.postBodyComponents}
-          </body>
-        </html>
-      </ErrorBoundary>
+          </ErrorBoundary>
+        </body>
+      </html>
     );
   }
 }

--- a/src/html.js
+++ b/src/html.js
@@ -1,23 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import ErrorBoundary from './components/ErrorBoundary';
+
 export default class HTML extends React.Component {
   render() {
     return (
-      <html {...this.props.htmlAttributes}>
-        <head>
-          <meta charSet="utf-8" />
-          <meta httpEquiv="x-ua-compatible" content="ie=edge" />
-          <meta
-            name="viewport"
-            content="width=device-width, initial-scale=1, shrink-to-fit=no"
-          />
-          {this.props.headComponents}
-        </head>
-        <body {...this.props.bodyAttributes} className="light">
-          <script
-            dangerouslySetInnerHTML={{
-              __html: `
+      <ErrorBoundary>
+        <html {...this.props.htmlAttributes}>
+          <head>
+            <meta charSet="utf-8" />
+            <meta httpEquiv="x-ua-compatible" content="ie=edge" />
+            <meta
+              name="viewport"
+              content="width=device-width, initial-scale=1, shrink-to-fit=no"
+            />
+            {this.props.headComponents}
+          </head>
+          <body {...this.props.bodyAttributes} className="light">
+            <script
+              dangerouslySetInnerHTML={{
+                __html: `
               (function() {
                 window.__onThemeChange = function() {};
                 function setTheme(newTheme) {
@@ -47,17 +50,18 @@ export default class HTML extends React.Component {
                 setTheme(preferredTheme || (darkQuery.matches ? 'dark' : 'light'));
               })();
             `,
-            }}
-          />
-          {this.props.preBodyComponents}
-          <div
-            key={`body`}
-            id="___gatsby"
-            dangerouslySetInnerHTML={{ __html: this.props.body }}
-          />
-          {this.props.postBodyComponents}
-        </body>
-      </html>
+              }}
+            />
+            {this.props.preBodyComponents}
+            <div
+              key={`body`}
+              id="___gatsby"
+              dangerouslySetInnerHTML={{ __html: this.props.body }}
+            />
+            {this.props.postBodyComponents}
+          </body>
+        </html>
+      </ErrorBoundary>
     );
   }
 }


### PR DESCRIPTION
Not sure high up the component tree you wanted to place the boundary, so I just put it at the very top. 

Let me know if you would like me to change the position, or add styling to the error message/link. Happy to do so! 👍 

Closes https://github.com/gaearon/overreacted.io/issues/149