### PR TITLE
Set '<meta name="theme-color" />' based on theme.

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -135,6 +135,7 @@ module.exports = {
         theme_color: `#ffa7c4`,
         display: `minimal-ui`,
         icon: `src/assets/icon.png`,
+        theme_color_in_head: false,
       },
     },
     `gatsby-plugin-react-helmet`,

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'gatsby';
 import Toggle from './Toggle';
+import Helmet from 'react-helmet';
 
 import { rhythm, scale } from '../utils/typography';
 import sun from '../assets/sun.png';
@@ -78,6 +79,14 @@ class Layout extends React.Component {
           minHeight: '100vh',
         }}
       >
+        <Helmet
+          meta={[
+            {
+              name: 'theme-color',
+              content: this.state.theme === 'light' ? '#ffa8c5' : '#282c35',
+            },
+          ]}
+        />
         <div
           style={{
             marginLeft: 'auto',


### PR DESCRIPTION
When selecting the dark theme on Chrome on Android, the pink is very bright compared to the rest. So this PR sets the `<meta name="theme-color" />` based on the current theme. 

Gif:

![feb-09-2019 03-12-42](https://user-images.githubusercontent.com/12477983/52515307-108da180-2c1a-11e9-9b8b-0f737361ab20.gif)
