### PR TITLE
js-to-jsx helper to run on pre-commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint": "^4.19.1",
     "eslint-plugin-react": "^7.11.1",
     "gh-pages": "^1.2.0",
+    "glob": "^7.1.3",
     "prettier": "^1.14.2"
   },
   "homepage": "https://overreacted.io",
@@ -56,7 +57,8 @@
     "build": "rm -rf public && rm -rf .cache && gatsby build",
     "now-build": "gatsby build",
     "deploy": "yarn build && cp now.json public/ && cd public && now alias $(now) overreacted.io",
-    "dry": "yarn build && cp now.json public/ && cd public && now"
+    "dry": "yarn build && cp now.json public/ && cd public && now",
+    "js-to-jsx": "node src/utils/js-to-jsx"
   },
   "husky": {
     "hooks": {
@@ -66,6 +68,10 @@
   "lint-staged": {
     "{gatsby-*.js,src/**/*.{js,jsx,json,css}}": [
       "yarn format",
+      "git add"
+    ],
+    "src/pages/**/*.md": [
+      "yarn run js-to-jsx",
       "git add"
     ]
   }

--- a/src/utils/js-to-jsx.js
+++ b/src/utils/js-to-jsx.js
@@ -1,0 +1,16 @@
+// It's so easy to forget to use ```jsx instead of ```js.
+// This will change every instance of js to jsx in blog posts.
+const fs = require('fs');
+const glob = require('glob');
+
+glob('src/pages/**/*.md', (err, files) => {
+  if (err) {
+    throw err;
+  }
+  files.forEach(file => {
+    fs.writeFileSync(
+      file,
+      fs.readFileSync(file, 'utf8').replace(/```js(?!x)/g, '```jsx')
+    );
+  });
+});


### PR DESCRIPTION
It's so easy to forget to use \`\`\`jsx instead of \`\`\`js. As I'm noticing new posts forgetting, particularly in translations.

This will change every instance in blog posts on pre-commit.