### PR TITLE
Use latest Prism, distinguish JSX tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "husky": "^1.3.1",
     "lint-staged": "^8.1.0",
     "lodash": "^4.17.11",
-    "prismjs": "^1.15.0",
+    "prismjs": "git+https://github.com/PrismJS/prism.git",
     "react": "^16.8.0-alpha.0",
     "react-dom": "^16.8.0-alpha.0",
     "react-helmet": "^5.2.0",

--- a/src/utils/global.css
+++ b/src/utils/global.css
@@ -177,10 +177,6 @@ pre[class*='language-'] ::selection {
   color: #56d9c0;
 }
 
-.token.parameter {
-  color: #9df4f1;
-}
-
 .token.tag .token.script {
   color: white;
 }

--- a/src/utils/global.css
+++ b/src/utils/global.css
@@ -168,10 +168,18 @@ pre[class*='language-'] ::selection {
   color: rgb(255, 203, 139);
 }
 
-.token.tag,
 .token.operator,
 .token.keyword {
   color: #ffa7c4;
+}
+
+.token.tag,
+.token.parameter {
+  color: #7ee9d5;
+}
+
+.token.tag .token.script {
+  color: white;
 }
 
 .token.boolean {

--- a/src/utils/global.css
+++ b/src/utils/global.css
@@ -173,9 +173,12 @@ pre[class*='language-'] ::selection {
   color: #ffa7c4;
 }
 
-.token.tag,
+.token.tag {
+  color: #56d9c0;
+}
+
 .token.parameter {
-  color: #7ee9d5;
+  color: #9df4f1;
 }
 
 .token.tag .token.script {


### PR DESCRIPTION
Prism hasn't had a release for a while but has had tons of new PRs which add useful tokens, so we'll link it in package.json.

- Distinguish JSX tags from keywords
- Distinguish components from native elements
- Parameter highlighting (doesn't work with destructured params though as of Prism master)
- Variables inside `{}` don't get the keyword color, they are the correct white color


Before:

![img](https://i.gyazo.com/3779acfd97bcd6322bee199fc0c9476f.png)

After:

![img](https://i.gyazo.com/03012a8399b473874c182788469f062b.png)
