### PR TITLE
Toggle checkbox display dark background for day mode too and redundancy of unit measure of 0px

### DIFF
--- a/src/components/Toggle.css
+++ b/src/components/Toggle.css
@@ -124,5 +124,5 @@
 .react-toggle:active .react-toggle-thumb {
   -webkit-box-shadow: 0 0 5px 5px rgb(255, 167, 196);
   -moz-box-shadow: 0 0 5px 5px rgb(255, 167, 196);
-  box-shadow: 0px 0 5px 5px rgb(255, 167, 196);
+  box-shadow: 0 0 5px 5px rgb(255, 167, 196);
 }

--- a/src/components/Toggle.css
+++ b/src/components/Toggle.css
@@ -20,7 +20,6 @@
   -ms-user-select: none;
   user-select: none;
 
-  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
   -webkit-tap-highlight-color: transparent;
 }
 
@@ -40,10 +39,18 @@
   height: 24px;
   padding: 0;
   border-radius: 30px;
-  background-color: hsl(222, 14%, 7%);
+  box-shadow: inset 0 0 1px 0 rgba(0, 0, 0, 0.75);
   -webkit-transition: all 0.2s ease;
   -moz-transition: all 0.2s ease;
   transition: all 0.2s ease;
+}
+
+.for-day {
+  background-color: #fff;
+}
+
+.for-night {
+  background-color: hsl(222, 14%, 7%);
 }
 
 .react-toggle-track-check {
@@ -51,8 +58,8 @@
   width: 17px;
   height: 17px;
   left: 5px;
-  top: 0px;
-  bottom: 0px;
+  top: 0;
+  bottom: 0;
   margin-top: auto;
   margin-bottom: auto;
   line-height: 0;
@@ -74,8 +81,8 @@
   width: 17px;
   height: 17px;
   right: 5px;
-  top: 0px;
-  bottom: 0px;
+  top: 0;
+  bottom: 0;
   margin-top: auto;
   margin-bottom: auto;
   line-height: 0;
@@ -96,7 +103,8 @@
   width: 22px;
   height: 22px;
   border-radius: 50%;
-  background-color: #fafafa;
+  background-color: #333;
+  border: 2px solid #fff;
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box;
@@ -105,17 +113,16 @@
 
 .react-toggle--checked .react-toggle-thumb {
   left: 27px;
-  border-color: #19ab27;
 }
 
 .react-toggle--focus .react-toggle-thumb {
-  -webkit-box-shadow: 0px 0px 3px 2px rgb(255, 167, 196);
-  -moz-box-shadow: 0px 0px 3px 2px rgb(255, 167, 196);
-  box-shadow: 0px 0px 2px 3px rgb(255, 167, 196);
+  -webkit-box-shadow: 0 0 3px 2px rgb(255, 167, 196);
+  -moz-box-shadow: 0 0 3px 2px rgb(255, 167, 196);
+  box-shadow: 0 0 2px 3px rgb(255, 167, 196);
 }
 
 .react-toggle:active .react-toggle-thumb {
-  -webkit-box-shadow: 0px 0px 5px 5px rgb(255, 167, 196);
-  -moz-box-shadow: 0px 0px 5px 5px rgb(255, 167, 196);
-  box-shadow: 0px 0px 5px 5px rgb(255, 167, 196);
+  -webkit-box-shadow: 0 0 5px 5px rgb(255, 167, 196);
+  -moz-box-shadow: 0 0 5px 5px rgb(255, 167, 196);
+  box-shadow: 0px 0 5px 5px rgb(255, 167, 196);
 }

--- a/src/components/Toggle.js
+++ b/src/components/Toggle.js
@@ -169,7 +169,13 @@ export default class Toggle extends PureComponent {
         onTouchEnd={this.handleTouchEnd}
         onTouchCancel={this.handleTouchCancel}
       >
-        <div className="react-toggle-track">
+        <div
+          className={
+            this.state.checked
+              ? 'react-toggle-track for-night'
+              : 'react-toggle-track for-day'
+          }
+        >
           <div className="react-toggle-track-check">
             {this.getIcon('checked')}
           </div>

--- a/src/utils/global.css
+++ b/src/utils/global.css
@@ -57,7 +57,7 @@ body:lang(fa) blockquote {
 /* styles for Persian language */
 body:lang(fa) article,
 body:lang(fa) h1 {
-  font-family: 'Vazir';
+  font-family: 'Vazir', sans-serif;
 }
 
 /**
@@ -161,7 +161,7 @@ pre[class*='language-'] ::selection {
 .token.selector,
 .token.doctype {
   color: rgb(199, 146, 234);
-  font-style: 'italic';
+  font-style: italic;
 }
 
 .token.class-name {


### PR DESCRIPTION
In src/utils/global.css:

1. Mismatched property value for 'font-style'.
2. Line 60, font property font-family does not have generic default. Added sans-serif.

Logic issue:

1. Toggle checkbox display dark background for day mode too.

Fixes added in src/components/Toggle.js:

* a ternary condition for react-toggle-track.

Fixed added in src/components/Toggle.css

* added for-day and for-night classes to differentiate and added box-shadow to match the feel.

Unit issue in src/components/Toggle.css:
Issue: Unit of measure 'px' is redundant in Toggle.css

* Fixed by replacing 0px to 0.