### PR TITLE
fix: change og meta tags to property instead of name attribute

### DIFF
--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -53,7 +53,7 @@ function SEO({ meta, image, title, description, slug, lang = 'en' }) {
                 content: title || siteMetadata.title,
               },
               {
-                name: 'og:description',
+                property: 'og:description',
                 content: metaDescription,
               },
               {


### PR DESCRIPTION
Open Graph uses the `property` attribute. Reference http://ogp.me/