### PR TITLE
Fix the link to the React Spring demo

### DIFF
--- a/src/pages/making-setinterval-declarative-with-react-hooks/index.md
+++ b/src/pages/making-setinterval-declarative-with-react-hooks/index.md
@@ -659,7 +659,7 @@ function Counter() {
 
 ## Closing Thoughts
 
-Hooks take some getting used to — and *especially* at the boundary of imperative and declarative code. You can create powerful declarative abstractions with them like [React Spring](http://react-spring.surge.sh/hooks) but they can definitely get on your nerves sometimes.
+Hooks take some getting used to — and *especially* at the boundary of imperative and declarative code. You can create powerful declarative abstractions with them like [React Spring](https://www.react-spring.io/docs/hooks/examples) but they can definitely get on your nerves sometimes.
 
 This is an early time for Hooks, and there are definitely still patterns we need to work out and compare. Don’t rush to adopt Hooks if you’re used to following well-known “best practices”. There’s still a lot to try and discover.
 


### PR DESCRIPTION
The link to the React Sprint demo, https://react-spring.surge.sh/hooks, is dead. I'm not sure what exactly was included there but perhaps the link to the hooks examples on their docs site would be appropriate here?
https://www.react-spring.io/docs/hooks/examples