### PR TITLE
Pass callback to useEffect updating savedCallback

### DIFF
--- a/src/pages/making-setinterval-declarative-with-react-hooks/index.md
+++ b/src/pages/making-setinterval-declarative-with-react-hooks/index.md
@@ -58,7 +58,7 @@ function useInterval(callback, delay) {
   // Remember the latest callback.
   useEffect(() => {
     savedCallback.current = callback;
-  });
+  }, [callback]);
 
   // Set up the interval.
   useEffect(() => {


### PR DESCRIPTION
The code snippet used near the beginning of the post didn't provide inputs to `useEffect`, needlessly updating the callback after every render. The CodeSandbox demo linked next to the snippet does pass the inputs array.

This PR makes the code snippet consistent with the CodeSandbox demo.