### PR TITLE
Give more insight into the "magic" of useReducer

### DIFF
--- a/src/pages/a-complete-guide-to-useeffect/index.md
+++ b/src/pages/a-complete-guide-to-useeffect/index.md
@@ -1125,6 +1125,8 @@ You may be wondering: how can this possibly work? How can the reducer “know”
 
 **This is why I like to think of `useReducer` as the “cheat mode” of Hooks. It lets me decouple the update logic from describing what happened. This, in turn, helps me remove unnecessary dependencies from my effects and avoid re-running them more often than necessary.**
 
+It feels like cheat mode because when you call dispatch with an action, this simply requests a new render and pushes your action to a pending action queue. But it isn't until the subsequent render phase when useReducer is called, _with the latest reducer function and its bound props_, that the action queue is processed to return the new state.
+
 ## Moving Functions Inside Effects
 
 A common mistake is to think functions shouldn’t be dependencies. For example, this seems like it could work:


### PR DESCRIPTION
As a deep dive blog post, it's helpful to demystify any of the magic behind counter-intuitive results. The "cheat mode" section I think merited a bit better explanation of how useReducer magically is aware of the latest props. I'm not 100% sure if my pseudo implementation actually is accurate but it's the best mental model I was able to come up with after reading this post and glancing through the React source. If it's inaccurate or works through a completely different implementation I'd love to see it :)