### PR TITLE
Relation between posts - "You Might Also Like"

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -61,6 +61,7 @@ exports.createPages = ({ graphql, actions }) => {
                   }
                   frontmatter {
                     title
+                    related
                   }
                 }
               }
@@ -116,11 +117,25 @@ exports.createPages = ({ graphql, actions }) => {
             translationsByDirectory[_.get(post, 'node.fields.directoryName')] ||
             [];
 
+          let related = null;
+          if (post.node.frontmatter.related) {
+            const relatedSlugs = post.node.frontmatter.related.map(
+              name => `/${name}/`
+            );
+            related = posts
+              .filter(post => relatedSlugs.includes(post.node.fields.slug))
+              .map(post => ({
+                title: post.node.frontmatter.title,
+                slug: post.node.fields.slug,
+              }));
+          }
+
           createPage({
             path: post.node.fields.slug,
             component: blogPost,
             context: {
               slug: post.node.fields.slug,
+              related,
               previous,
               next,
               translations,

--- a/src/pages/preparing-for-tech-talk-part-1-motivation/index.md
+++ b/src/pages/preparing-for-tech-talk-part-1-motivation/index.md
@@ -2,6 +2,7 @@
 title: 'Preparing for a Tech Talk, Part 1: Motivation'
 date: '2018-12-26'
 spoiler: Here’s my recipe for a good talk idea.
+related: [preparing-for-tech-talk-part-2-what-why-and-how]
 ---
 
 I’ve done a [few](https://www.youtube.com/watch?v=xsSnOQynTHs) [tech](https://www.youtube.com/watch?v=nLF0n9SACd4) [talks](https://www.youtube.com/watch?v=dpw9EHDh2bM) that I think went well.

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -135,6 +135,10 @@ class BlogPostTemplate extends React.Component {
       `https://overreacted.io${enSlug}`
     )}`;
 
+    const relatedPost = related
+      ? related[Math.floor(Math.random() * related.length)]
+      : null;
+
     return (
       <Layout location={this.props.location} title={siteTitle}>
         <SEO
@@ -220,12 +224,12 @@ class BlogPostTemplate extends React.Component {
                 padding: 0,
               }}
             >
-              {related && (
+              {relatedPost && (
                 <>
                   <li>You may also like: </li>
                   <li>
-                    <Link to={related[0].slug} rel="next">
-                      {related[0].title} →
+                    <Link to={relatedPost.slug} rel="next">
+                      {relatedPost.title} →
                     </Link>
                   </li>
                 </>

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -226,7 +226,7 @@ class BlogPostTemplate extends React.Component {
             >
               {relatedPost && (
                 <>
-                  <li>You may also like: </li>
+                  <li>You might also like: </li>
                   <li>
                     <Link to={relatedPost.slug} rel="next">
                       {relatedPost.title} →

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -98,6 +98,7 @@ class BlogPostTemplate extends React.Component {
       previous,
       next,
       slug,
+      related,
       translations,
       translatedLinks,
     } = this.props.pageContext;
@@ -219,6 +220,26 @@ class BlogPostTemplate extends React.Component {
                 padding: 0,
               }}
             >
+              {related && (
+                <>
+                  <li>You may also like: </li>
+                  <li>
+                    <Link to={related[0].slug} rel="next">
+                      {related[0].title} →
+                    </Link>
+                  </li>
+                </>
+              )}
+            </ul>
+            <ul
+              style={{
+                display: 'flex',
+                flexWrap: 'wrap',
+                justifyContent: 'space-between',
+                listStyle: 'none',
+                padding: 0,
+              }}
+            >
               <li>
                 {previous && (
                   <Link
@@ -263,6 +284,7 @@ export const pageQuery = graphql`
         title
         date(formatString: "MMMM DD, YYYY")
         spoiler
+        related
       }
       fields {
         slug


### PR DESCRIPTION
Added a feature that allows to set a `related` list in frontmatter header to "link" posts that might be interesting for the reader that just finished the current post.

The idea of this feature comes from #178 