### PR TITLE
Add Gatsby scroll indicator plugin

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -159,5 +159,11 @@ module.exports = {
       },
     },
     `gatsby-plugin-catch-links`,
+    {
+      resolve: `gatsby-plugin-scroll-indicator`,
+      options: {
+        color: '#FFA6C4',
+      },
+    },
   ],
 };

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "gatsby-plugin-manifest": "^2.0.5",
     "gatsby-plugin-offline": "^2.0.5",
     "gatsby-plugin-react-helmet": "^3.0.0",
+    "gatsby-plugin-scroll-indicator": "0.0.8",
     "gatsby-plugin-sharp": "^2.0.16",
     "gatsby-plugin-typography": "^2.2.0",
     "gatsby-remark-autolink-headers": "2.0.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -652,6 +652,13 @@
     "@babel/plugin-transform-react-jsx-self" "^7.0.0"
     "@babel/plugin-transform-react-jsx-source" "^7.0.0"
 
+"@babel/runtime@7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.3.1.tgz#574b03e8e8a9898eaf4a872a92ea20b7846f6f2a"
+  integrity sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.2.0.tgz#b03e42eeddf5898e00646e4c840fa07ba8dcad7f"
@@ -5295,6 +5302,13 @@ gatsby-plugin-react-helmet@^3.0.0:
   integrity sha512-Xn8d4EckfUkO3xB8qfjn1AcqeA2fYgd6Mbin3RHc/Zu6YRiOQqdJAVBXz+7PbFpTt+6GCluKklEpFUA4RS4oYw==
   dependencies:
     "@babel/runtime" "^7.0.0"
+
+gatsby-plugin-scroll-indicator@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-scroll-indicator/-/gatsby-plugin-scroll-indicator-0.0.8.tgz#d5160e059f5449d556d540b143d572244d3f8c14"
+  integrity sha512-qjmtu1bEB1BvBSY3i9eFL/CidPpRgQZTa9GJHsWNfXXVGPIqrEZYFdJ8aPyWzfQPoE5gBJHZDRW6ebibhLq0vg==
+  dependencies:
+    "@babel/runtime" "7.3.1"
 
 gatsby-plugin-sharp@^2.0.16:
   version "2.0.17"


### PR DESCRIPTION
This [little Gatsby plugin](https://www.gatsbyjs.org/packages/gatsby-plugin-scroll-indicator/) provides the reader with a visual indicator of far they have left to scroll on any page.

I think this works really well on your site as many of your articles are deep dives and subsequently quite long.

Disclosure: I am the [author of this plugin](https://www.barrymcgee.co.uk/notes/gatsby-plugin-scroll-indicator)

## QA

- Pull this feature branch
- Run `yarn install`
- Run `gatsby develop`
- Navigate to http://localhost:8000/
- Scroll on any page and observe 3px scroll indicator progress along the top of the viewport, using your brand accent color `#FFA6C4`
- Works well with both dark and light themes

## Screenshot

<img width="1268" alt="Screenshot 2019-03-15 at 11 09 38" src="https://user-images.githubusercontent.com/505570/54427651-024c0d00-4713-11e9-9bfb-6ef01c02bb48.png">


 
