### PR TITLE
Explain why setCount can be ignored from deps

### DIFF
--- a/src/pages/a-complete-guide-to-useeffect/index.md
+++ b/src/pages/a-complete-guide-to-useeffect/index.md
@@ -906,7 +906,7 @@ Issues like this are difficult to think about. Therefore, I encourage you to ado
 
 There are two strategies to be honest about dependencies. You should generally start with the first one, and then apply the second one if needed.
 
-**The first strategy is to fix the dependency array to include _all_ the values inside the component that are used inside the effect.** Let’s include `count` as a dep:
+**The first strategy is to fix the dependency array to include _all_ the values inside the component that are used inside the effect.** We could include both `count` and `setCount` as deps, as they are set outside `useEffect`, but as you'll see later in this article, the implementation of `useState` garantees that `setCount` will never change, so we can safely ignore it:
 
 ```jsx{3,6}
 useEffect(() => {


### PR DESCRIPTION
I was reading this repeatedly awesome article when I suddenly stopped understanding and felt betrayed.

At some point, you share the following code:
```js
useEffect(() => {
    const id = setInterval(() => {
      setCount(count + 1);
    }, 1000);
    return () => clearInterval(id);
  }, []);
```

And tell the reader that you will not lie about deps because it is Bad React Hooks Practice.

With the following solution: 

> The first strategy is to fix the dependency array to include _all_ the values inside the component that are used inside the effect. **Let's add `count` in the deps array.**


I was like: *well, that's interesting, what about `setCount`? Who is lying now?*

To continue angrily reading until line 1075:
> (You may omit `dispatch`, `setState`, and `useRef` container values from the deps because React guarantees them to be static. But it also doesn’t hurt to specify them.)

This PR will help future readers to not feel temporarily offended by their own ignorance 🎉 