### PR TITLE
mistakingly -> mistakenly

### DIFF
--- a/src/pages/writing-resilient-components/index.md
+++ b/src/pages/writing-resilient-components/index.md
@@ -440,7 +440,7 @@ There one more case where you might accidentally ignore changes to props. This m
 
 Note that optimization approaches that use shallow equality like `PureComponent` and `React.memo` with the default comparison are safe.
 
-**However, if you try to “optimize” a component by writing your own comparison, you may mistakingly forget to compare function props:**
+**However, if you try to “optimize” a component by writing your own comparison, you may mistakenly forget to compare function props:**
 
 ```jsx{2-5,7}
 class Button extends React.Component {


### PR DESCRIPTION
[_Mistakingly_](https://en.wiktionary.org/wiki/mistakingly) is in fact a word (TIL!), but the dictionaries I've checked suggest that [_mistakenly_](https://en.wiktionary.org/wiki/mistakenly) is the preferred form for the sense of "by accident, by mistake, in error (without intention to do so)".

Love the article, by the way!