### PR TITLE
Add alias for `www.overreacted.io` to `now.json`.

### DIFF
--- a/now.json
+++ b/now.json
@@ -20,7 +20,14 @@
       "headers": { "cache-control": "public, max-age=0, must-revalidate" }
     }
   ],
-  "alias": ["overreacted.io", "www.overreacted.io"],
+  "alias": ["www.overreacted.io"],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "status": 301,
+      "headers": { "Location": "https://overreacted.io/$1" }
+    }
+  ],
   "builds": [
     { "use": "@now/static-build", "src": "package.json", "config": { "distDir": "public" } }
   ]

--- a/now.json
+++ b/now.json
@@ -20,7 +20,7 @@
       "headers": { "cache-control": "public, max-age=0, must-revalidate" }
     }
   ],
-  "alias": "overreacted.io",
+  "alias": ["overreacted.io", "www.overreacted.io"],
   "builds": [
     { "use": "@now/static-build", "src": "package.json", "config": { "distDir": "public" } }
   ]


### PR DESCRIPTION
Fixes https://github.com/gaearon/overreacted.io/issues/440.

See their documentation [here](https://zeit.co/docs/v2/deployments/configuration#alias). Live example [here](https://www.leerob.io/) and [source code here](https://github.com/leerob/leerob.io/blob/master/now.json#L2).