### PR TITLE
refactor package.json build script to use `gatsby clean`

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "format": "prettier --write '{gatsby-*.js,src/**/*.{js,jsx,json,css}}'",
     "develop": "gatsby develop",
     "start": "npm run develop",
-    "build": "rm -rf public && rm -rf .cache && gatsby build",
+    "build": "gatsby clean && gatsby build",
     "now-build": "gatsby build",
     "deploy": "yarn build && cp now.json public/ && cd public && now alias $(now) overreacted.io",
     "dry": "yarn build && cp now.json public/ && cd public && now"


### PR DESCRIPTION
- use `gatsby-cli`'s [`clean`](https://www.gatsbyjs.org/docs/gatsby-cli/#clean) command rather than manually deleting `.cache` and `public` directories
- reason: more idiomatic and since this repo will likely serve as an example for many newcomers to Gatsby, it makes sense to establish best practices