### PR TITLE
OCD: Fix <code> background in dark mode

### DIFF
--- a/src/utils/global.css
+++ b/src/utils/global.css
@@ -23,7 +23,7 @@ body.dark {
   --textTitle: #ffffff;
   --textLink: var(--pink);
   --hr: hsla(0, 0%, 100%, 0.2);
-  --inlineCode-bg: hsl(222, 14%, 25%);
+  --inlineCode-bg: rgba(115, 124, 153, 0.2);
   --inlineCode-text: #e6e6e6;
 }
 


### PR DESCRIPTION
_Sorry, this is an OCD issue._

In dark mode, there is no 0.2 transparency on `<code>` tags, resulting in hiding the most of the `<a>`'s underline when there is a `<code>` inside of an `<a>`.

This made me look into transparency calculus (thanks for the opportunity), and according to this [Wikipedia article on transparency](https://en.wikipedia.org/wiki/Transparency_%28graphic%29), rgba(115,124, 153, 0.2) should render the same color on the dark background as the hsl(222, 14%, 25%) you are currently using.

Here you have a 'before' and 'after' screenshot.

<img width="176" alt="Screenshot 2019-05-16 at 23 38 31" src="https://user-images.githubusercontent.com/277455/57889836-2c669c00-7836-11e9-8c33-05996bb54289.png">
<img width="174" alt="Screenshot 2019-05-16 at 23 38 42" src="https://user-images.githubusercontent.com/277455/57889838-2ec8f600-7836-11e9-80d0-f6f226538f95.png">

PS: thanks for adding the dark mode, perfect for my bedtime stories