### PR TITLE
Adding dark mode styling to the signup component

### DIFF
--- a/src/components/Signup.css
+++ b/src/components/Signup.css
@@ -309,7 +309,6 @@
   }
 }
 .formkit-form {
-  box-shadow: 0 2px 15px 0 rgba(210, 214, 220, 0.5);
   max-width: 700px;
   overflow: hidden;
 }

--- a/src/components/Signup.js
+++ b/src/components/Signup.js
@@ -10,19 +10,23 @@ class Signup extends React.Component {
         className="seva-form formkit-form"
         method="post"
         min-width="400 500 600 700 800"
-        style={{ backgroundColor: 'rgb(255, 255, 255)', borderRadius: '6px' }}
+        style={{
+          boxShadow: 'var(--form-shadow)',
+          backgroundColor: 'var(--bg)',
+          borderRadius: '6px',
+        }}
       >
         <div data-style="full">
           <div
             data-element="column"
             className="formkit-column"
-            style={{ backgroundColor: 'rgb(249, 250, 251)' }}
+            style={{ backgroundColor: 'var(--bg-secondary)' }}
           >
             <h1
               className="formkit-header"
               data-element="header"
               style={{
-                color: 'rgb(77, 77, 77)',
+                color: 'var(--textTitle)',
                 fontSize: '20px',
                 fontWeight: 700,
               }}
@@ -32,7 +36,7 @@ class Signup extends React.Component {
             <div
               data-element="subheader"
               className="formkit-subheader"
-              style={{ color: 'rgb(104, 104, 104)' }}
+              style={{ color: 'var(--textNormal)' }}
             >
               <p>Subscribe to get my latest content by email.</p>
             </div>
@@ -126,7 +130,7 @@ class Signup extends React.Component {
               data-element="guarantee"
               className="formkit-guarantee"
               style={{
-                color: 'rgb(77, 77, 77)',
+                color: 'var(--textNormal)',
                 fontSize: '13px',
                 fontWeight: 400,
               }}

--- a/src/utils/global.css
+++ b/src/utils/global.css
@@ -5,6 +5,7 @@ body {
 
 body.light {
   --bg: #ffffff;
+  --bg-secondary: rgb(249, 250, 251);
   --header: var(--pink);
   --textNormal: #222;
   --textTitle: #222;
@@ -12,12 +13,14 @@ body.light {
   --hr: hsla(0, 0%, 0%, 0.2);
   --inlineCode-bg: rgba(255, 229, 100, 0.2);
   --inlineCode-text: #1a1a1a;
+  --form-shadow: 0 2px 15px 0 rgba(210, 214, 220, 0.5);
 }
 
 body.dark {
   -webkit-font-smoothing: antialiased;
 
   --bg: #282c35;
+  --bg-secondary: rgb(54, 60, 72);
   --header: #ffffff;
   --textNormal: rgba(255, 255, 255, 0.88);
   --textTitle: #ffffff;
@@ -25,6 +28,7 @@ body.dark {
   --hr: hsla(0, 0%, 100%, 0.2);
   --inlineCode-bg: hsl(222, 14%, 25%);
   --inlineCode-text: #e6e6e6;
+  --form-shadow: 0 2px 15px 0 rgba(26, 26, 27, 0.637);
 }
 
 /*


### PR DESCRIPTION
Found my self reading at night and was blinded by the bright white signup box at the bottom of the posts even while in dark mode. I have added styling to the background of the signup container and text to make it more in line with the rest of the sites styling while in dark mode. Please let me know if this needs any changes to meet your standards!

Would love to see this added to save others eyes 👁 👍 

Current:
![image](https://user-images.githubusercontent.com/6362515/61760119-10c8c600-ad90-11e9-8061-9b5f2676f663.png)

Change in this PR:
![image](https://user-images.githubusercontent.com/6362515/61760130-1c1bf180-ad90-11e9-801e-626448f2ad20.png)
