### PR TITLE
Remove redundant react imports from useInterval

### DIFF
--- a/src/pages/making-setinterval-declarative-with-react-hooks/index.md
+++ b/src/pages/making-setinterval-declarative-with-react-hooks/index.md
@@ -50,7 +50,7 @@ function Counter() {
 This `useInterval` isn’t a built-in React Hook; it’s a [custom Hook](https://reactjs.org/docs/hooks-custom.html) that I wrote:
 
 ```jsx
-import React, { useState, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
 function useInterval(callback, delay) {
   const savedCallback = useRef();


### PR DESCRIPTION
The `useInterval` example as https://overreacted.io/making-setinterval-declarative-with-react-hooks/#just-show-me-the-code includes some unused imports.

Remove unnecessary `React` and `{ useState }` imports.