### PR TITLE
Remove useState from useInterval code

### DIFF
--- a/src/pages/making-setinterval-declarative-with-react-hooks/index.md
+++ b/src/pages/making-setinterval-declarative-with-react-hooks/index.md
@@ -50,7 +50,7 @@ function Counter() {
 This `useInterval` isn’t a built-in React Hook; it’s a [custom Hook](https://reactjs.org/docs/hooks-custom.html) that I wrote:
 
 ```jsx
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 function useInterval(callback, delay) {
   const savedCallback = useRef();


### PR DESCRIPTION
Removing useState from the useInterval as its not used in the custom hook.