### PR TITLE
Signup to newsletter component: allow dark theme via css-in-js

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -11,12 +11,16 @@ class Layout extends React.Component {
   state = {
     theme: null,
   };
-  componentDidMount() {
+
+  changeTheme = () => {
     this.setState({ theme: window.__theme });
-    window.__onThemeChange = () => {
-      this.setState({ theme: window.__theme });
-    };
+  };
+
+  componentDidMount() {
+    this.changeTheme();
+    window.addEventListener('__onThemeChange', this.changeTheme);
   }
+
   renderHeader() {
     const { location, title } = this.props;
     const rootPath = `${__PATH_PREFIX__}/`;

--- a/src/components/Signup.css
+++ b/src/components/Signup.css
@@ -70,7 +70,6 @@
   padding: 12px 24px;
 }
 .formkit-form .formkit-input {
-  background: #ffffff;
   font-size: 15px;
   padding: 12px;
   border: 1px solid #e3e3e3;

--- a/src/components/Signup.js
+++ b/src/components/Signup.js
@@ -3,26 +3,54 @@ import React from 'react';
 import './Signup.css';
 
 class Signup extends React.Component {
+  state = {
+    theme: null,
+  };
+
+  changeTheme = () => {
+    this.setState({ theme: window.__theme });
+  };
+
+  componentDidMount() {
+    this.changeTheme();
+    window.addEventListener('__onThemeChange', this.changeTheme);
+  }
+
   render() {
     return (
       <form
+        id="signup-form"
         action="https://app.convertkit.com/forms/812047/subscriptions"
         className="seva-form formkit-form"
         method="post"
         min-width="400 500 600 700 800"
-        style={{ backgroundColor: 'rgb(255, 255, 255)', borderRadius: '6px' }}
+        style={{
+          backgroundColor:
+            this.state.theme === 'light'
+              ? 'rgb(255, 255, 255)'
+              : 'rgb(40, 44, 53)',
+          borderRadius: '6px',
+        }}
       >
         <div data-style="full">
           <div
             data-element="column"
             className="formkit-column"
-            style={{ backgroundColor: 'rgb(249, 250, 251)' }}
+            style={{
+              backgroundColor:
+                this.state.theme === 'light'
+                  ? 'rgb(249, 250, 251)'
+                  : 'rgb(30, 33, 40)',
+            }}
           >
             <h1
               className="formkit-header"
               data-element="header"
               style={{
-                color: 'rgb(77, 77, 77)',
+                color:
+                  this.state.theme === 'light'
+                    ? 'rgb(77, 77, 77)'
+                    : 'rgb(211, 211, 211)',
                 fontSize: '20px',
                 fontWeight: 700,
               }}
@@ -85,9 +113,19 @@ class Signup extends React.Component {
                   placeholder="Your first name"
                   type="text"
                   style={{
-                    borderColor: 'rgb(227, 227, 227)',
+                    backgroundColor:
+                      this.state.theme === 'light'
+                        ? '#ffffff'
+                        : 'rgb(23, 23, 23)',
+                    borderColor:
+                      this.state.theme === 'light'
+                        ? 'rgb(227, 227, 227)'
+                        : '#000',
                     borderRadius: '4px',
-                    color: 'rgb(0, 0, 0)',
+                    color:
+                      this.state.theme === 'light'
+                        ? 'rgb(0, 0, 0)'
+                        : 'rgba(255, 255, 255, 0.88)',
                     fontWeight: 400,
                   }}
                 />
@@ -101,9 +139,19 @@ class Signup extends React.Component {
                   required=""
                   type="email"
                   style={{
-                    borderColor: 'rgb(227, 227, 227)',
+                    backgroundColor:
+                      this.state.theme === 'light'
+                        ? '#ffffff'
+                        : 'rgb(23, 23, 23)',
+                    borderColor:
+                      this.state.theme === 'light'
+                        ? 'rgb(227, 227, 227)'
+                        : '#000',
                     borderRadius: '4px',
-                    color: 'rgb(0, 0, 0)',
+                    color:
+                      this.state.theme === 'light'
+                        ? 'rgb(0, 0, 0)'
+                        : 'rgba(255, 255, 255, 0.88)',
                     fontWeight: 400,
                   }}
                 />
@@ -126,7 +174,6 @@ class Signup extends React.Component {
               data-element="guarantee"
               className="formkit-guarantee"
               style={{
-                color: 'rgb(77, 77, 77)',
                 fontSize: '13px',
                 fontWeight: 400,
               }}

--- a/src/html.js
+++ b/src/html.js
@@ -19,12 +19,12 @@ export default class HTML extends React.Component {
             dangerouslySetInnerHTML={{
               __html: `
               (function() {
-                window.__onThemeChange = function() {};
+                var evtThemeChange = new Event('__onThemeChange');
                 function setTheme(newTheme) {
                   window.__theme = newTheme;
                   preferredTheme = newTheme;
                   document.body.className = newTheme;
-                  window.__onThemeChange(newTheme);
+                  window.dispatchEvent(evtThemeChange);
                 }
 
                 var preferredTheme;


### PR DESCRIPTION
This PR solves that Signup component wont 'react' (ba dum tss!) on changing theme.

It also solves an issue that makes "__onThemeChange" been unable to be listened on inner components, even replicating exactly how is done on the Layout.js component.
This new way works everywhere, and so on the Signup component to set its own theme state.

![signup-dark](https://user-images.githubusercontent.com/23552631/65834790-e854cf00-e2de-11e9-9250-26399101a276.gif)

I just saw theres another PR solving this same issue purely on css, which is great, but I didnt see it until now and also as the Signup component was using css-in-js I decided to implement a css-in-js solution.