### PR TITLE
Improve theme persistent (slightly)

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -9,7 +9,7 @@ import moon from '../assets/moon.png';
 
 class Layout extends React.Component {
   state = {
-    theme: null,
+    theme: window.__theme || null,
   };
   componentDidMount() {
     this.setState({ theme: window.__theme });
@@ -69,7 +69,6 @@ class Layout extends React.Component {
   }
   render() {
     const { children } = this.props;
-
     return (
       <div
         style={{

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -9,7 +9,7 @@ import moon from '../assets/moon.png';
 
 class Layout extends React.Component {
   state = {
-    theme: window.__theme || null,
+    theme: (window && window.__theme) || null,
   };
   componentDidMount() {
     this.setState({ theme: window.__theme });
@@ -67,6 +67,7 @@ class Layout extends React.Component {
       );
     }
   }
+
   render() {
     const { children } = this.props;
     return (

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -67,9 +67,9 @@ class Layout extends React.Component {
       );
     }
   }
-
   render() {
     const { children } = this.props;
+
     return (
       <div
         style={{


### PR DESCRIPTION
I was trying to implement the same theme/mode toggling and persistent on my Gatsby website, but I was using hooks, and I've experienced that toggle component was blinking every time I switched the route.
Then I realized that hooks might be a bit slower in this case (than `componentDidMount`), because on overreacted there is no such case.
I figured out that the problem was that every time `this.state.theme` was set to `null` on layout re-render. I've set it to `window.__theme`, and it solved the problem.
I know that it's a very little change, but I've still decided to contribute here, maybe it will be beneficial in the future 🙂