### PR TITLE
Fix: Cannot query field "maybeAbsoluteLinks"

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -202,7 +202,10 @@ exports.onCreateNode = ({ node, actions }) => {
     createNodeField({
       node,
       name: 'maybeAbsoluteLinks',
-      value: _.uniq(maybeAbsoluteLinks),
+      value:
+        _.uniq(maybeAbsoluteLinks).length !== 0
+          ? _.uniq(maybeAbsoluteLinks)
+          : '',
     });
   }
 };


### PR DESCRIPTION
In the case where blog websites does not have any blog that includes a link (nothing in any markdown page match pattern `/\]\((\/[^\)]+\/)\)/g`), markdown remark will not generate `maybeAbsoluteLinks` field in GraphQL. This will cause an error in GraphQL query, and no page is built.
Passing empty string to `createNodeField` will ensure `maybeAbsoluteLinks` always appear.