### PR TITLE
Add less restrictive license for code snippets

### DIFF
--- a/LICENSE-code-snippets
+++ b/LICENSE-code-snippets
@@ -1,5 +1,5 @@
-Code snippets included in posts on the site are licensed under more permissive terms than the totatily of the post content.
-(Please see LICENSE-posts for the terms regarding general post content.)
+Code snippets included in posts on the site are licensed under more permissive terms than general post content.
+Please see LICENSE-posts for the terms regarding general post content.
 
 Code snippets may be used under the terms of the MIT License:
 

--- a/LICENSE-code-snippets
+++ b/LICENSE-code-snippets
@@ -1,0 +1,26 @@
+Code snippets included in posts on the site are licensed under more permissive terms than the totatily of the post content.
+(Please see LICENSE-posts for the terms regarding general post content.)
+
+Code snippets may be used under the terms of the MIT License:
+
+MIT License
+
+Copyright (c) 2020 Dan Abramov and the contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE-posts
+++ b/LICENSE-posts
@@ -1,2 +1,4 @@
 Copyright (c) Dan Abramov and the contributors.
 All rights reserved.
+
+(Please see LICENSE-code-snippets for the terms regarding use of code snippets found in posts.)


### PR DESCRIPTION
As per the discussion in https://github.com/gaearon/overreacted.io/issues/473#issuecomment-568909346,this PR adds a less restrictive license for code snippet.

Classic disclaimer that I'm not a lawyer, so I have no idea if this is legally sufficient or not, but seems like a reasonable set up to me hopefully!