### PR TITLE
Email subscription form - validation

### DIFF
--- a/src/components/Signup.js
+++ b/src/components/Signup.js
@@ -117,6 +117,7 @@ class Signup extends React.Component {
                     color: 'rgb(0, 0, 0)',
                     fontWeight: 400,
                   }}
+                  required
                 />
               </div>
               <div className="formkit-field">
@@ -125,7 +126,7 @@ class Signup extends React.Component {
                   name="email_address"
                   aria-label="Your email address"
                   placeholder="Your email address"
-                  required=""
+                  required
                   type="email"
                   style={{
                     borderColor: 'rgb(227, 227, 227)',


### PR DESCRIPTION
Validation is not preset in email subscription form. I tried using empty name and invalid email address, it still accepts. I was thinking it would be better if a front end level validation was there. Just added required attribute in the form inputs.