### PR TITLE
Remove unused imports from `useInterval` snippet

### DIFF
--- a/src/pages/making-setinterval-declarative-with-react-hooks/index.md
+++ b/src/pages/making-setinterval-declarative-with-react-hooks/index.md
@@ -50,7 +50,7 @@ function Counter() {
 This `useInterval` isn’t a built-in React Hook; it’s a [custom Hook](https://reactjs.org/docs/hooks-custom.html) that I wrote:
 
 ```jsx
-import React, { useState, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
 function useInterval(callback, delay) {
   const savedCallback = useRef();


### PR DESCRIPTION
I come back often to this article to copy the hook and I always have to remove the unused imports.

Given that there is no other context in this snippet besides the hook itself I propose deleting the `React` and `useState` imports from it.