### PR TITLE
docs(declarative-setInterval): Disable by default

### DIFF
--- a/src/pages/making-setinterval-declarative-with-react-hooks/index.md
+++ b/src/pages/making-setinterval-declarative-with-react-hooks/index.md
@@ -52,7 +52,7 @@ This `useInterval` isn’t a built-in React Hook; it’s a [custom Hook](https:/
 ```jsx
 import React, { useState, useEffect, useRef } from 'react';
 
-function useInterval(callback, delay) {
+function useInterval(callback, delay = null) {
   const savedCallback = useRef();
 
   // Remember the latest callback.


### PR DESCRIPTION
Current `useInterval` will run with no delay if the delay is omitted. This is problematic for environments like codesandbox that reload while typing. `useInterval(callback)` would cause a refresh and the callback to be called with no delay. 

This PR changes the default to `null` so that the interval isn't scheduled when setting up the hook. Zero timeout behavior can still be achieved with `useInterval(callback, 0)`.