### PR TITLE
fixed old link

### DIFF
--- a/src/pages/react-as-a-ui-runtime/index.es.md
+++ b/src/pages/react-as-a-ui-runtime/index.es.md
@@ -1110,7 +1110,7 @@ YourComponent();
 fiber.hooks = hooks;
 ```
 
-*(Si sientes curiosidad, el código real está [aquí](https://github.com/facebook/react/blob/master/packages/react-reconciler/src/ReactFiberHooks.js)).*
+*(Si sientes curiosidad, el código real está [aquí](https://github.com/facebook/react/blob/master/packages/react-reconciler/src/ReactFiberHooks.new.js)).*
 
 Esto es a grandes rasgos como cada llamada a `useState()` obtiene el estado correcto. Como aprendimos [antes](#conciliación), «hacer coincidir las cosas» no es nuevo para React. La conciliación depende de una manera similar en que los elementos coincidan entre los renderizados.
 

--- a/src/pages/react-as-a-ui-runtime/index.fr.md
+++ b/src/pages/react-as-a-ui-runtime/index.fr.md
@@ -1108,7 +1108,7 @@ YourComponent();
 fiber.hooks = hooks;
 ```
 
-*(Si vous êtes curieux·se, le véritable code est [ici](https://github.com/facebook/react/blob/master/packages/react-reconciler/src/ReactFiberHooks.js).)*
+*(Si vous êtes curieux·se, le véritable code est [ici](https://github.com/facebook/react/blob/master/packages/react-reconciler/src/ReactFiberHooks.new.js).)*
 
 C’est *grosso modo* comme ça que les appels à `useState()` obtiennent le bon état.  Comme nous l’avons vu [plus tôt](#réconciliation), « faire correspondre des trucs » n’a rien de nouveau pour React—la réconciliation repose de façon similaire sur la correspondance entre éléments d’un rendu à l’autre.
 

--- a/src/pages/react-as-a-ui-runtime/index.ko.md
+++ b/src/pages/react-as-a-ui-runtime/index.ko.md
@@ -1110,7 +1110,7 @@ YourComponent();
 fiber.hooks = hooks;
 ```
 
-**(궁금하시다면 [여기](https://github.com/facebook/react/blob/master/packages/react-reconciler/src/ReactFiberHooks.js)에서 실제 코드를 볼 수 있습니다.)**
+**(궁금하시다면 [여기](https://github.com/facebook/react/blob/master/packages/react-reconciler/src/ReactFiberHooks.new.js)에서 실제 코드를 볼 수 있습니다.)**
 
 각 `useState()`가 올바른 상태를 얻는 대략적인 방법입니다. [재조정](#reconciliation)에서 배운 것처럼 '일치시키기'는 React에 새로운 개념이 아닙니다. 재조정은 비슷한 방법으로 렌더링마다 일치하는 엘리먼트에 의존합니다.
 

--- a/src/pages/react-as-a-ui-runtime/index.md
+++ b/src/pages/react-as-a-ui-runtime/index.md
@@ -1112,7 +1112,7 @@ YourComponent();
 fiber.hooks = hooks;
 ```
 
-*(If you’re curious, the real code is [here](https://github.com/facebook/react/blob/master/packages/react-reconciler/src/ReactFiberHooks.js).)*
+*(If you’re curious, the real code is [here](https://github.com/facebook/react/blob/master/packages/react-reconciler/src/ReactFiberHooks.new.js).)*
 
 This is roughly how each `useState()` call gets the right state. As we’ve learned [earlier](#reconciliation), “matching things up” isn’t new to React — reconciliation relies on the elements matching up between renders in a similar way.
 

--- a/src/pages/react-as-a-ui-runtime/index.pt-br.md
+++ b/src/pages/react-as-a-ui-runtime/index.pt-br.md
@@ -1113,7 +1113,7 @@ YourComponent();
 fiber.hooks = hooks;
 ```
 
-*(Se você for uma pessoa curiosa, o código real está [aqui](https://github.com/facebook/react/blob/master/packages/react-reconciler/src/ReactFiberHooks.js).)*
+*(Se você for uma pessoa curiosa, o código real está [aqui](https://github.com/facebook/react/blob/master/packages/react-reconciler/src/ReactFiberHooks.new.js).)*
 
 Isso é basicamente como cada chamada a `useState()` encontra o estado correto. Como aprendemos [mais cedo](#reconciliação), "comparar as coisas" não é novo para o React - a reconciliação se baseia nos elementos sendo comparados entre renderizações de maneira semelhante.
 

--- a/src/pages/react-as-a-ui-runtime/index.zh-hans.md
+++ b/src/pages/react-as-a-ui-runtime/index.zh-hans.md
@@ -1108,7 +1108,7 @@ YourComponent();
 fiber.hooks = hooks;
 ```
 
-*(如果你对它感兴趣，真正的代码在[这里](https://github.com/facebook/react/blob/master/packages/react-reconciler/src/ReactFiberHooks.js) 。)* 
+*(如果你对它感兴趣，真正的代码在[这里](https://github.com/facebook/react/blob/master/packages/react-reconciler/src/ReactFiberHooks.new.js) 。)* 
 
 这大致就是每个 `useState()` 如何获得正确状态的方式。就像我们[之前](#协调)所知道的，“匹配”对 React 来说并不是什么新的知识 — 这与协调依赖于在渲染前后元素是否匹配是同样的道理。
 


### PR DESCRIPTION
Fixed old link that leads to 404 page in https://overreacted.io/react-as-a-ui-runtime/ 