### PR TITLE
why-isnt-x-a-hook [pt-br]: fix typos and grammar

### DIFF
--- a/src/pages/why-isnt-x-a-hook/index.pt-br.md
+++ b/src/pages/why-isnt-x-a-hook/index.pt-br.md
@@ -20,7 +20,7 @@ Mas existem outras APIs, como `React.memo()` e `<Context.Provider>`, que *não* 
 
 Há duas importantes propriedades que queremos preservar nas APIs do React:
 
-1. **Composição:** Os [Hooks customizados](https://reactjs.org/docs/hooks-custom.html) são a razão principal por estarmos entusiasmados com a API dos Hooks. Esperamos que as pessoas criem seus própios Hooks frequentemente, e precisamos ter certeza que os Hooks escritos por pessoas diferentes [não entrem em conflito](/why-do-hooks-rely-on-call-order/#flaw-4-the-diamond-problem). (Não estamos todos mimados na forma em que os componentes conseguem se compor de forma limpa e sem quebrar um ao outro?)
+1. **Composição:** Os [Hooks customizados](https://reactjs.org/docs/hooks-custom.html) são a razão principal por estarmos entusiasmados com a API dos Hooks. Esperamos que as pessoas criem seus próprios Hooks frequentemente, e precisamos ter certeza que os Hooks escritos por pessoas diferentes [não entrem em conflito](/why-do-hooks-rely-on-call-order/#flaw-4-the-diamond-problem). (Não estamos todos mimados pela forma em que os componentes conseguem se compor de forma limpa e sem quebrar um ao outro?)
 
 2. **Depuração:** Queremos que os erros sejam [fáceis de se encontrar](/the-bug-o-notation/) a medida que a aplicação cresce. Uma das melhores funcionalidades do React é que se vemos algo renderizado da maneira incorreta, podemos percorrer a árvore acima até encontrar qual prop ou estado de componente que causou o erro.
 
@@ -87,13 +87,13 @@ Mas e se cometermos um erro? Como funciona a depuração?
 
 Vamos dizer que a classe CSS que obtemos de `theme.comment` está errada. Como depuramos isso? Podemos colocar um `breakpoint` ou alguns *logs* no corpo de nosso componente.
 
-Talvez iríamos notar que `theme` está errada, mas `width` e `isMobile` estão corretas. Isso nos indicaria que o problema está dentro de `useTheme()`. Ou talvez iríamos ver que `width` está errada. Isso nos indicaria para verificar dentro de `useWindowWidth()`.
+Talvez notássemos que `theme` está errada, mas `width` e `isMobile` estão corretas. Isso nos indicaria que o problema está dentro de `useTheme()`. Ou talvez víssemos que `width` está errada. Isso nos indicaria para verificar dentro de `useWindowWidth()`.
 
-**Uma única verificação aos valores intermediários nos diria qual o Hook no nível superior que contém o erro.** Não precisaríamos de olhar **todas** as suas implementações.
+**Uma única verificação aos valores intermediários nos diria qual o Hook no nível superior que contém o erro.** Não precisaríamos olhar **todas** as suas implementações.
 
 Então podemos "verificar mais de perto" aquele que contém um erro e repetir.
 
-Isso se torna mais importante se a profundidade de aninhamento de Hooks customizados aumentar. Imagine que temos 3 níveis de aninhamento, cada nível usando 3 Hooks customizados diferentes dentro. A [diferença](/the-bug-o-notation/) entre procurar por um erro em **3 lugares** contra potencialmente procurar **3 + 3×3 + 3×3×3 = 39 lugares** é enorme. Por sorte, `useState()` não pode magicamente "influenciar" outros Hooks ou componentes. Um valor errado retornado por ele deixa um rastro, assim como qualquer outra variável. 🐛
+Isso se torna mais importante se a profundidade de aninhamento de Hooks customizados aumentar. Imagine que temos 3 níveis de aninhamento, cada nível usando 3 Hooks customizados diferentes dentro. A [diferença](/the-bug-o-notation/) entre procurar por um erro em **3 lugares**, contra potencialmente procurar **3 + 3×3 + 3×3×3 = 39 lugares** é enorme. Por sorte, `useState()` não pode magicamente "influenciar" outros Hooks ou componentes. Um valor errado retornado por ele deixa um rastro, assim como qualquer outra variável. 🐛
 
 **Veredito:** ✅ `useState()` não obscurece a relação causa-efeito em nosso código. Podemos seguir o rastro diretamente até o erro.
 
@@ -101,9 +101,9 @@ Isso se torna mais importante se a profundidade de aninhamento de Hooks customiz
 
 ## Não é um Hook: `useBailout()`
 
-Como uma otimização, componentes que utilizam Hooks podem "se livrar" (do inglês *bail out*) de voltar a serem renderizados.
+Como uma otimização, componentes que utilizam Hooks podem "se livrar" (do inglês *bail out*) de serem re-renderizados.
 
-Uma forma de fazer isso é encapsular todo o componente com um [`React.memo()`](https://reactjs.org/blog/2018/10/23/react-v-16-6.html#reactmemo). Ele deixa de voltar a renderizar se as props são superficialmente iguais ao que tínhamos durante a última renderização. Isso o faz similar a um `PureComponent` em classes.
+Uma forma de fazer isso é encapsular todo o componente com um [`React.memo()`](https://reactjs.org/blog/2018/10/23/react-v-16-6.html#reactmemo). Ele deixa de re-renderizar se as props são superficialmente iguais ao que tínhamos durante a última renderização. Isso o faz similar a um `PureComponent` em classes.
 
 `React.memo()` recebe um componente e retorna um componente:
 
@@ -116,7 +116,7 @@ export default React.memo(Button);
 
 **Mas por quê isso não é simplesmente um Hook?**
 
-Não importa se você o chamarmos de `useShouldComponentUpdate()`, `usePure()`, `useSkipRender()` ou `useBailout()`, a implementação deve se parecer com algo assim:
+Não importa se você o chamar de `useShouldComponentUpdate()`, `usePure()`, `useSkipRender()` ou `useBailout()`, a implementação deverá se parecer com algo assim:
 
 ```jsx
 function Button({ color }) {
@@ -131,11 +131,11 @@ function Button({ color }) {
 }
 ```
 
-Há algumas variações (por exemplo um simples marcador `usePure()`) mas no final eles possuem as mesmas falhas.
+Há algumas variações (por exemplo, um simples marcador `usePure()`), mas no final eles possuem as mesmas falhas.
 
 ### Composição
 
-Digamos que tentamos colocar `useBailout()` em dois Hooks customizados:
+Digamos que tentemos colocar `useBailout()` em dois Hooks customizados:
 
 ```jsx{4,5,19,20}
 function useFriendStatus(friendID) {
@@ -185,13 +185,13 @@ function ChatThread({ friendID, isTyping }) {
 }
 ```
 
-Quando ele irá voltar a renderizar?
+Quando ele irá re-renderizar?
 
 Se cada chamada a `useBailout()` tem o poder de pular uma atualização, então as atualizações de `useWindowWidth()` seriam bloqueadas por `useFriendStatus()`, e vice-versa. **Esses Hooks iriam quebrar um ao outro.**
 
 Porém, se `useBailout()` fosse respeitado apenas quando *todas* as chamadas dentro de um único componente "concordassem" em bloquear uma atualização, nosso `ChatThread` iria falhar em atualizar nas mudanças da prop `isTyping`.
 
-Pior ainda, com essa semântica **qualquer Hook que fosse adicionado a `ChatThread` iria quebrar se eles não chamassem *também* a `useBailout()`**. De outra forma, eles não poderiam "votar contra" de deixar de atualizar dentro de `useWindowWidth()` e `useFriendStatus()`.
+Pior ainda, com essa semântica **qualquer Hook que fosse adicionado a `ChatThread` iria quebrar se eles não chamassem *também* a `useBailout()`**. De outra forma, eles não poderiam "votar contra" a atualização dentro de `useWindowWidth()` e `useFriendStatus()`.
 
 **Veredito:** 🔴 `useBailout()` quebra a composição. Adicionar ele a um Hook quebra a atualização de estado em outros Hooks. Nós queremos que as APIs sejam [antifrágeis](/optimized-for-change/), e esse comportamento é praticamente o oposto.
 
@@ -214,13 +214,13 @@ function ChatThread({ friendID, isTyping }) {
 }
 ```
 
-Digamos que a *label* `Typing...` não apareça quando se espera, apesar de que em algum lugar muitos níveis acima a prop está sendo alterada. Como depuramos isso?
+Digamos que a *label* `Typing...` não apareça quando se espera, apesar de que em algum lugar, muitos níveis acima, a prop está sendo alterada. Como depuramos isso?
 
 **Normalmente, em React podemos responder essa questão com segurança olhando *para os níveis acima*.** Se `ChatThread` não obtém um novo valor `isTyping`, podemos abrir o componente que renderiza `<ChatThread isTyping={myVar} />` e checar `myVar`, e assim por diante. Em algum desses níveis, ou vamos encontrar uma implementação errada de `shouldComponentUpdate()`, ou um valor incorreto de `isTyping` sendo passado para baixo. Apenas uma verificação em cada componente da cadeia de renderização é geralmente suficiente para localizar a origem do problema.
 
 Contudo, se esse Hook `useBailout()` fosse real, nunca saberíamos a razão pela qual uma atualização foi pulada até que verificássemos *cada um dos Hooks customizados* (em profundidade) usado pelo nosso componente `ChatThread` e os componentes em suas cadeias de renderização. Visto que todo componente pai pode *também* utilizar Hooks customizados, isso iria tomar uma [proporção terrível](/the-bug-o-notation/)
 
-É como se você estivesse procurando por uma chave de fenda em uma cômoda cheia de gavetas, e cada gaveta teria diversas outras cômodas menores, e você não saberia até quando continuaria assim.
+É como se você estivesse procurando por uma chave de fenda em um baú cheio de gavetas, e cada gaveta tivesse diversos outros baús menores com gavetas, e você não sabe até onde isso vai.
 
 **Veredito:** 🔴 O Hook `useBailout()` não apenas quebra a composição, mas também aumenta de forma ampla o número de passos para se depurar e a carga cognitiva para encontrar uma otimização com erros - em alguns casos, exponencialmente.
 


### PR DESCRIPTION
Fixes:
- typos
- semantics in some phrases
- some verbs conjugations

Adjusts the translation of "re-rendering" to "re-renderizar", same as used in https://pt-br.reactjs.org/