### PR TITLE
Remove unused imports in useInterval source

### DIFF
--- a/src/pages/making-setinterval-declarative-with-react-hooks/index.md
+++ b/src/pages/making-setinterval-declarative-with-react-hooks/index.md
@@ -50,7 +50,7 @@ function Counter() {
 This `useInterval` isn’t a built-in React Hook; it’s a [custom Hook](https://reactjs.org/docs/hooks-custom.html) that I wrote:
 
 ```jsx
-import React, { useState, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
 function useInterval(callback, delay) {
   const savedCallback = useRef();


### PR DESCRIPTION
The snippet with the source code for `useInterval` has some unused imports: `React` (default) and `useState`.

This small change removes those imports.

Cheers!