### PR TITLE
Improve zh-hans for before-you-memo

### DIFF
--- a/src/pages/before-you-memo/index.zh-hans.md
+++ b/src/pages/before-you-memo/index.zh-hans.md
@@ -8,12 +8,12 @@ spoiler: "自然产生的渲染优化"
 
 1. 验证是否正在运行一个生产环境的构建。（开发环境构建会刻意地缓慢一些，极端情况下可能会慢一个数量级）
 2. 验证是否将树中的状态放在了一个比实际所需更高的位置上。（例如，将输入框的state放到了集中的store里可能不是一个好主意）
-3. 运行React开发者工具来检测是什么导致了二次渲染，以及在高开销的子树上包裹`memo()`。（以及在需要的地方使用`useMemo()`）
+3. 运行React开发者工具来检测是什么导致了二次渲染，并且用`memo()`包裹高开销的子树。（以及在需要的地方使用`useMemo()`）
 
 
 最后一步是很烦人的，特别是对于介于两者之间的组件，理想情况下，编译器可以为您完成这一步。未来也许会。
 **在这篇文章里，我想分享两种不同的技巧。** 它们十分基础，这也正是为什么人们很少会意识到它们可以提升渲染性能。
-**这些技巧和你已经知道的内容是互补的** 它们并不会替代`memo` 或者 `useMemo`，但是先试一试它们还是不错的
+**这些技巧和你已经知道的内容是互补的** 它们并不会替代`memo` 或者 `useMemo`，但是先试一试它们通常是不错的。
 
 ## 一个（人工）减缓的组件
 
@@ -46,10 +46,9 @@ function ExpensiveTree() {
 *([在这里试试](https://codesandbox.io/s/frosty-glade-m33km?file=/src/App.js:23-513))*
 
 
-问题就是当`App`中的`color`变化时，我们会重新渲染一次被我们手动大幅延缓渲染的`<ExpensiveTree />`组件。
-我可以直接在它[上面写个memo()](https://codesandbox.io/s/amazing-shtern-61tu4?file=/src/App.js)然后收工大吉，但是现在已经有很多这方面的文章了，所以我不会再花时间讲解如何使用memo()来优化。我只想展示
-两种不同的解决方案。
-
+问题是当`App`中的`color`变化时，我们会重新渲染一次被我们故意大幅延缓渲染的`<ExpensiveTree />`组件。
+我可以直接在它[上面写个memo()](https://codesandbox.io/s/amazing-shtern-61tu4?file=/src/App.js)然后收工大吉，但是已经有很多关于这方面的文章，所以我就不花时间继续讲解这个了。我只想展示
+两种不一样的解决方案。
 
 ## 解法 1： 向下移动State
 
@@ -116,7 +115,7 @@ export default function App() {
 
 
 
-在沙盒中玩玩吧，然后看看你是否可以解决。
+在CodeSandbox的例子中试试看你是否可以解决这个问题。
 ...
 
 ...
@@ -156,16 +155,15 @@ function ColorPicker({ children }) {
 
 ## 寓意是什么？
 
-在你用`memo`或者`useMemo`做优化时，如果你可以从不变的部分里分割出变化的部分，那么这看起来可能是有意义的。
-关于这些方式有趣的部分是**他们本身并不真的和性能有关**. 使用children属性来拆分组件通常会使应用程序的数据流更容易追踪，并且可以减少贯穿树的props数量。在这种情况下提高性能是锦上添花，而不是最终目标。
-奇怪的是，这种模式在将来还会带来更多的性能好处。
-For example, when [Server Components](https://reactjs.org/blog/2020/12/21/data-fetching-with-react-server-components.html) are stable and ready for adoption, our `ColorPicker` component could receive its `children` [from the server](https://youtu.be/TQQPAU21ZUw?t=1314). Either the whole `<ExpensiveTree />` component or its parts could run on the server, and even a top-level React state update would "skip over" those parts on the client.
-举个例子，当[服务器组件](https://reactjs.org/blog/2020/12/21/data-fetching-with-react-server-components.html) 稳定且可被采用时，我们的`ColorPicker`组件就可以从服务器上获取到它的`children`。
-整个`<ExpensiveTree />`组件或其部分都可以在服务器上运行，即使是顶级的React状态更新也会在客户机上“跳过”这些部分。
-这是`memo`做不到的事情!但是，这两种方法是互补的。不要忽视state下移(和内容提升!)
-然后，如果这还不够，那就使用Profiler然后用memo来写吧。
+在用`memo`或者`useMemo`做优化之前，你也许可以先试试看能否从不变的部分里分离出变化的部分，说不定会有些许收获。
+关于这些方式有趣的部分是**他们本身并不真的和性能有关**. 使用children属性来拆分组件通常会使应用程序的数据流更容易追踪，并且可以减少贯穿树的属性数量。在这种情况下提高性能是锦上添花，而不是最终目标。
+小小意外的是，这种模式在将来还会带来更多的性能好处。
+举个例子，当[服务端组件](https://reactjs.org/blog/2020/12/21/data-fetching-with-react-server-components.html) 稳定且可被采用时，我们的`ColorPicker`组件就可以从服务器上获取到它的`children`。
+整个`<ExpensiveTree />`组件或其部分都可以在服务器上运行，即使是顶层的React状态更新也会在客户端“跳过”这些部分。
+这是`memo`做不到的事情! 但是，这两种方法是互补的。不要忽视下移state(和提升内容!)
+然后，如果这些还不够，那就使用Profiler然后用memo来实现吧。
 
-## 我之前不是读过这个吗？
+## 我之前是不是读过这个？
 
 [大概是的吧](https://kentcdodds.com/blog/optimize-react-re-renders)
 


### PR DESCRIPTION
Small improvement for the Simplified Chinese translation of article [Before You memo()](https://overreacted.io/before-you-memo/) see if it can help a bit.

Very good and intuitive article 👍
Cheers