### PR TITLE
Unify savedCallback's effect dependencies

### DIFF
--- a/src/pages/making-setinterval-declarative-with-react-hooks/index.md
+++ b/src/pages/making-setinterval-declarative-with-react-hooks/index.md
@@ -429,7 +429,7 @@ This mutable `savedCallback` needs to “persist” across the re-renders. So it
   // After every render, save the latest callback into our ref.
   useEffect(() => {
     savedCallback.current = callback;
-  });
+  }, [callback]);
 ```
 
 And then we can read and call it from inside our interval:
@@ -460,7 +460,7 @@ function Counter() {
 
   useEffect(() => {
     savedCallback.current = callback;
-  });
+  }, [callback]);
 
   useEffect(() => {
     function tick() {
@@ -507,7 +507,7 @@ function useInterval(callback) {
 
   useEffect(() => {
     savedCallback.current = callback;
-  });
+  }, [callback]);
 
   useEffect(() => {
     function tick() {
@@ -565,7 +565,7 @@ function useInterval(callback, delay) {
 
   useEffect(() => {
     savedCallback.current = callback;
-  });
+  }, [callback]);
 
   useEffect(() => {
     function tick() {


### PR DESCRIPTION
There are two different "versions" for the effect that saves the callback in this post, one has a dependency array (with "callback") and one does not. 
The TL;DR of the custom hook at the top of the post uses the version with dependency array, this commit unifies all other effects of the post to use the version with dependency array.

![image](https://user-images.githubusercontent.com/29319414/113704586-9f07eb80-96dc-11eb-9238-85c6c3c135cb.png)
