### PR TITLE
fix(a-complete-guide-to-useeffect): typo

### DIFF
--- a/src/pages/a-complete-guide-to-useeffect/index.zh-hans.md
+++ b/src/pages/a-complete-guide-to-useeffect/index.zh-hans.md
@@ -904,7 +904,7 @@ function Counter() {
 
 *(依赖没有变，所以不会再次运行effect。)*
 
-类似于这样的问题是很难被想到的。因此，我鼓励你将诚实地告知effect依赖作为一条硬性规则，并且要列出所以依赖。（我们提供了一个[lint规则](https://github.com/facebook/react/issues/14920)如果你想在你的团队内做硬性规定。）
+类似于这样的问题是很难被想到的。因此，我鼓励你将诚实地告知effect依赖作为一条硬性规则，并且要列出所有依赖。（我们提供了一个[lint规则](https://github.com/facebook/react/issues/14920)如果你想在你的团队内做硬性规定。）
 
 ## 两种诚实告知依赖的方法
 


### PR DESCRIPTION
`所以` means `thus`，`所有` means `all`.