### PR TITLE
Example fix on "Teaching React to Diff Your Effects" section

### DIFF
--- a/src/pages/a-complete-guide-to-useeffect/index.md
+++ b/src/pages/a-complete-guide-to-useeffect/index.md
@@ -711,7 +711,7 @@ For example, maybe our component re-renders because of a state change:
 
 ```jsx{11-13}
 function Greeting({ name }) {
-  const [counter, setCounter] = useState(0);
+  const [count, setCounter] = useState(0);
 
   useEffect(() => {
     document.title = 'Hello, ' + name;

--- a/src/pages/a-complete-guide-to-useeffect/index.md
+++ b/src/pages/a-complete-guide-to-useeffect/index.md
@@ -711,7 +711,7 @@ For example, maybe our component re-renders because of a state change:
 
 ```jsx{11-13}
 function Greeting({ name }) {
-  const [count, setCounter] = useState(0);
+  const [count, setCount] = useState(0);
 
   useEffect(() => {
     document.title = 'Hello, ' + name;
@@ -720,7 +720,7 @@ function Greeting({ name }) {
   return (
     <h1 className="Greeting">
       Hello, {name}
-      <button onClick={() => setCounter(count + 1)}>
+      <button onClick={() => setCount(count + 1)}>
         Increment
       </button>
     </h1>


### PR DESCRIPTION
Under the section "Teaching React to Diff Your Effects", the first example has a wrong variable name