### PR TITLE
Fix JSX props log for Greeting

### DIFF
--- a/public/a-chain-reaction/index.md
+++ b/public/a-chain-reaction/index.md
@@ -177,7 +177,7 @@ Take a look at what JSX is made of.
 ```js
 const originalJSX = <Greeting person={alice} />;
 console.log(originalJSX.type);  // Greeting
-console.log(originalJSX.props); // { firstName: 'Alice', birthYear: 1970 }
+console.log(originalJSX.props); // { person: { firstName: 'Alice', birthYear: 1970 } }
 ```
 
 Under the hood, JSX constructs an object with the `type` property corresponding to the tag, and the `props` property corresponding to the JSX attributes.
@@ -210,7 +210,7 @@ You can verify that feeding my original piece of JSX to `translateForBrowser` wi
 ```js {5-7}
 const originalJSX = <Greeting person={alice} />;
 console.log(originalJSX.type);  // Greeting
-console.log(originalJSX.props); // { firstName: 'Alice', birthYear: 1970 }
+console.log(originalJSX.props); // { person: { firstName: 'Alice', birthYear: 1970 } }
 
 const browserJSX = translateForBrowser(originalJSX);
 console.log(browserJSX.type);  // 'p'


### PR DESCRIPTION
Noticed that log of Greeting props in recent post was raw `alice` object instead of `{ person: alice }`
Also not this pr related, but avatar on the site was ruined cause the link to now closed twitter acc, I think