### PR TITLE
Update page.js to Fix Bug Error displaying images in posts

### DIFF
--- a/app/[slug]/page.js
+++ b/app/[slug]/page.js
@@ -53,6 +53,12 @@ export default async function PostPage({ params }) {
           source={content}
           components={{
             a: Link,
+            img: (props) => {
+              if (props.src && !/^https?:\/\//.test(props.src)) {
+                props.src = `/${params.slug}/${props.src}`;
+              }
+              return <img {...props} />;
+            },
             ...postComponents,
           }}
           options={{

--- a/app/[slug]/page.js
+++ b/app/[slug]/page.js
@@ -53,11 +53,12 @@ export default async function PostPage({ params }) {
           source={content}
           components={{
             a: Link,
-            img: (props) => {
-              if (props.src && !/^https?:\/\//.test(props.src)) {
-                props.src = `/${params.slug}/${props.src}`;
+            img: ({ src, ...rest }) => {
+              if (src && !/^https?:\/\//.test(src)) {
+                // https://github.com/gaearon/overreacted.io/issues/827
+                src = `/${params.slug}/${src}`;
               }
-              return <img {...props} />;
+              return <img src={src} {...rest} />;
             },
             ...postComponents,
           }}


### PR DESCRIPTION
Bug: On mobile device. Visit the [overreacted.io](https://overreacted.io/), click on any article containing an image. The image in the article will not display, you will have to refresh the article to display the image.

Issue: https://github.com/gaearon/overreacted.io/issues/827

Need to handle adding the article slug to the img's src in page.js, add img to MDXRemote.