### PR TITLE
Switch to npm-run-all2

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "gray-matter": "^4.0.3",
     "next": "^14.0.1-canary.2",
     "next-mdx-remote": "^4.4.1",
-    "npm-run-all": "^4.1.5",
+    "npm-run-all2": "^6.2.0",
     "overnight": "^1.8.0",
     "react": "^18",
     "react-dom": "^18",


### PR DESCRIPTION
I help maintain [npm-run-all2](https://github.com/bcomnes/npm-run-all2), the community fork of npm-run-all and noticed you were still running the original, but sadly neglected version. This fixes a bunch of small issues and keeps on top of security updates. Beyond that, it's just the npm-run-all we all love with maintenance.