### PR TITLE
Fix formatting in index.md

### DIFF
--- a/public/npm-audit-broken-by-design/index.md
+++ b/public/npm-audit-broken-by-design/index.md
@@ -192,7 +192,7 @@ Looks like this “Moderate” “vulnerability” was neither moderate nor a vu
 
 **Verdict: this “vulnerability” is absurd in this context.**
 
-### Third “vulnerability”
+### Third “vulnerability”
 
 Let’s have a look at this one:
 


### PR DESCRIPTION
Replace a no-break-space, which was causing the heading to format incorrectly, with a normal space.