### PR TITLE
Fix typo (`interpert` -> `interpret`)

### DIFF
--- a/public/react-for-two-computers/index.md
+++ b/public/react-for-two-computers/index.md
@@ -734,7 +734,7 @@ function interpret(json, knownTags) {
 }
 ```
 
-Now, if you pass empty `knownTags` to `interpert`, you'll get the original call tree:
+Now, if you pass empty `knownTags` to `interpret`, you'll get the original call tree:
 
 ```js
 interpret(greeting(), {});


### PR DESCRIPTION
Just noticed this typo while reading. Fantastic article by the way!