### PR TITLE
fix: typo (`json` -> `primitives`)

### DIFF
--- a/public/react-for-two-computers/index.md
+++ b/public/react-for-two-computers/index.md
@@ -2961,7 +2961,7 @@ Now you can finally pass it to `interpret`, executing the `Clock`. That will giv
 
 ```js
 const primitives = interpret(lateComponents);
-const tree = perform(json);
+const tree = perform(primitives);
 document.body.appendChild(tree);
 ```
 


### PR DESCRIPTION
Just fixed a minor typo in the code snippet. By the way, thanks for the insightful and well-written article!