### PR TITLE
JSX Over The Wire: PostDetailsRouteViewModel → PostListRouteViewModel

### DIFF
--- a/public/jsx-over-the-wire/index.md
+++ b/public/jsx-over-the-wire/index.md
@@ -2234,7 +2234,7 @@ function RouterViewModel({ url }) {
     const {postId} = parseRoute(url, '/screen/post-details/:postId');
     route = <PostDetailsRouteViewModel postId={postId} />;
   } else if (matchRoute(url, '/screen/post-list')) {
-    route = <PostDetailsRouteViewModel />;
+    route = <PostListRouteViewModel />;
   }
   return route;
 }


### PR DESCRIPTION
Points to the correct `<PostListRouteViewModel />` when the url matches `'/screen/post-list'`.