### PR TITLE
Remove unused property `postId` for PostList route

### DIFF
--- a/public/jsx-over-the-wire/index.md
+++ b/public/jsx-over-the-wire/index.md
@@ -2247,7 +2247,7 @@ async function PostDetailsRouteViewModel({ postId }) {
   return <PostDetailsViewModel postId={postId} />
 }
 
-async function PostListRouteViewModel({ postId }) {
+async function PostListRouteViewModel() {
   const postIds = await getRecentPostIds();
   return (
     <>
@@ -2416,7 +2416,7 @@ export async function PostDetailsRoute({ postId }) {
   return <Post postId={postId} />
 }
 
-export async function PostListRoute({ postId }) {
+export async function PostListRoute() {
   const postIds = await getRecentPostIds();
   return (
     <>


### PR DESCRIPTION
I'm not sure if we need to pass the `postId` to the list components since we will be fetching posts based on the recentPostIds.