### PR TITLE
fix: quotes in React for Two Computers

### DIFF
--- a/public/react-for-two-computers/index.md
+++ b/public/react-for-two-computers/index.md
@@ -1427,7 +1427,7 @@ Time smirks at you.
 
 *"This isn't going to work, is it? Functions need to know their arguments."*
 
-"*Some* of them do."
+``*Some* of them do."
 
 You look over all the functions in your program to see whether they *introspect* the stuff you're nesting inside their tags or merely *embed* it without introspection:
 


### PR DESCRIPTION
`retext-smartypants` incorrectly determines that the first quote should be the closing one in this sentence:

```md
"*Some* of them do."
```

Fixing this by forcing opening quote with backticks.