### PR TITLE
feat(markdown): add support for tables using remark-gfm

### DIFF
--- a/app/[slug]/markdown.css
+++ b/app/[slug]/markdown.css
@@ -112,6 +112,19 @@
     color: #222;
 }
 
+.markdown table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 1.5rem;
+}
+
+.markdown th,
+.markdown td {
+    border: 1px solid #dcdcdc;
+    padding: 8px;
+    text-align: left;
+}
+
 @media (prefers-color-scheme: dark) {
     .markdown input {
         color: #111;

--- a/app/[slug]/page.js
+++ b/app/[slug]/page.js
@@ -11,6 +11,7 @@ import rehypeAutolinkHeadings from "rehype-autolink-headings";
 import { remarkMdxEvalCodeBlock } from "./mdx.js";
 import overnight from "overnight/themes/Overnight-Slumber.json";
 import "./markdown.css";
+import remarkGfm from "remark-gfm";
 
 overnight.colors["editor.background"] = "var(--code-bg)";
 
@@ -29,10 +30,10 @@ export default async function PostPage({ params }) {
   let Wrapper = postComponents.Wrapper ?? Fragment;
   const { content, data } = matter(file);
   const discussUrl = `https://bsky.app/search?q=${encodeURIComponent(
-    `https://overreacted.io/${slug}/`,
+    `https://overreacted.io/${slug}/`
   )}`;
   const editUrl = `https://github.com/gaearon/overreacted.io/edit/main/public/${encodeURIComponent(
-    slug,
+    slug
   )}/index.md`;
   return (
     <>
@@ -80,6 +81,7 @@ export default async function PostPage({ params }) {
                   useDynamicImport: true,
                   remarkPlugins: [
                     remarkSmartpants,
+                    remarkGfm,
                     [remarkMdxEvalCodeBlock, filename],
                   ],
                   rehypePlugins: [

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "rehype-autolink-headings": "^7.1.0",
     "rehype-pretty-code": "^0.10.2",
     "rehype-slug": "^6.0.0",
+    "remark-gfm": "^4.0.1",
     "remark-smartypants": "^2.0.0",
     "shiki": "^0.14.5"
   },


### PR DESCRIPTION
This pull request fixes #851 by adding support for tables within the Markdown renderer.
- install remark-gfm and update package.json
- configure MDXRemote in app/[slug]/page.js to render tables
- add css styles for tables, th and td

Before:

![image](https://github.com/user-attachments/assets/182f28e8-9ec5-4b45-8638-acfd7772636c)

After:

![image](https://github.com/user-attachments/assets/d82cf17f-bbf8-46c4-8f82-673551baa98c)
