### PR TITLE
fix: typo in latest post "Impossible Components"

### DIFF
--- a/public/impossible-components/index.md
+++ b/public/impossible-components/index.md
@@ -440,7 +440,7 @@ async function SortableFileList({ directory }) {
 }
 ```
 
-Of course, this doesn't make sense. The information `readdir` needs only exists on *my* computer but the sorting order you choose with `useState` lives on *your* computer. (The most I *could* do on mine is to prepare HTML for the initial state.)
+Of course, this doesn't make sense. The information `readdir` only exists on *my* computer but the sorting order you choose with `useState` lives on *your* computer. (The most I *could* do on mine is to prepare HTML for the initial state.)
 
 How do we fix this component?
 


### PR DESCRIPTION
Not the right place to fix and notify you (but I have no social media so this is the only place I can reach out I think?)
There's a small typo on your (excellent) post:

I think you mean

> "Of course, this doesn’t make sense. The information `readdir` **only exists** on my computer but..."

instead of the current:

> "Of course, this doesn’t make sense. The information `readdir` **needs only exists** on my computer but..."