### PR TITLE
fix: typo in final code example on "jsx-over-the-wire" article

### DIFF
--- a/public/jsx-over-the-wire/index.md
+++ b/public/jsx-over-the-wire/index.md
@@ -2435,7 +2435,7 @@ async function Post({
 }) {
   const post = await getPost(postId);
   return (
-    <PostLayout
+    <PostDetails
       postTitle={post.title}
       postContent={parseMarkdown(post.content, {
         maxParagraphs: truncateContent ? 1 : undefined
@@ -2446,7 +2446,7 @@ async function Post({
         postId={postId}
         includeAvatars={includeAvatars}
       />
-    </PostLayout>
+    </PostDetails>
   );
 }
 
@@ -2477,7 +2477,7 @@ return (
 ```js
 'use client';
 
-export function PostLayout({
+export function PostDetails({
   postTitle,
   postContent,
   postAuthor,


### PR DESCRIPTION
Replace PostLayout (used in `server` part but not defined) with PostDetails (used in `client` part)
(thanks a lot for this amazing article!)