### PR TITLE
Add immutable header

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -3,3 +3,6 @@
 
 /:post/opengraph-image
   Content-Type: image/png
+
+/_next/static/*
+  Cache-Control: public,max-age=31536000,immutable


### PR DESCRIPTION
May fix https://bsky.app/profile/danabra.mov/post/3lqnluvhtss27 in some cases? Not sure, but at least this changes how the CSS is served.

While the static assets are cached, that doesn't mean that the browser will not make a request anyway. 

The default header for static assets in Cloudflare is `public, max-age=0, must-revalidate`, which tells the browser to check that the file wasn't changed before using it. This isn't useful on files that are immutable, with a hash on their path.
So to fix this, a `immutable` header is added to inform the browser that it doesn't need to revalidate files inside the `_next/static` immutable directory.

Related cloudflare issue: https://github.com/opennextjs/opennextjs-cloudflare/issues/624

