### PR TITLE
Replace SVG white backgrounds with theme-aware colors

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -91,7 +91,7 @@ export default async function PostPage({
                     const colorReplacedSvg = svgContent
                       .replace(/#ffffff/gi, "var(--bg-rotated)")
                       .replace(/<metadata>.*?<\/metadata>/s, '')
-                      .replace("<svg", '<svg style="max-width: 450px; width: auto; height: auto;"');
+                      .replace("<svg", '<svg style="max-width: 450px; width: 100%; height: auto;"');
 
                     return (
                       <span

--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -90,6 +90,7 @@ export default async function PostPage({
                     const svgContent = await readFile(svgPath, "utf8");
                     const colorReplacedSvg = svgContent
                       .replace(/#ffffff/gi, "var(--bg-rotated)")
+                      .replace(/<metadata>.*?<\/metadata>/s, '')
                       .replace("<svg", '<svg style="max-width: 450px; width: auto; height: auto;"');
 
                     return (

--- a/app/global.css
+++ b/app/global.css
@@ -19,6 +19,7 @@
         --text: rgba(255, 255, 255, 0.88);
         --title: white;
         --bg: rgb(40, 44, 53);
+        --bg-rotated: hsl(from var(--bg) calc(h - 180deg) s l);
         --code-bg: #191d27;
         --link: #ffa7c4;
         --inlineCode-bg: rgba(115, 124, 153, 0.2);
@@ -62,4 +63,9 @@
     * {
         transition: none !important;
     }
+}
+
+:root { --bg-rotated: white; }
+@media (prefers-color-scheme: dark) {
+    :root { --bg-rotated: rgb(221, 225, 236); }
 }

--- a/app/global.css
+++ b/app/global.css
@@ -19,7 +19,6 @@
         --text: rgba(255, 255, 255, 0.88);
         --title: white;
         --bg: rgb(40, 44, 53);
-        --bg-rotated: hsl(from var(--bg) calc(h - 180deg) s l);
         --code-bg: #191d27;
         --link: #ffa7c4;
         --inlineCode-bg: rgba(115, 124, 153, 0.2);


### PR DESCRIPTION
## Summary
• Inline local SVGs and replace #ffffff with background-rotated color that works correctly under the hue-rotate filter
• Limit SVG max-width to 450px for better layout
• Standardize all SVG white colors to use consistent #ffffff

## Test plan
- [x] Check SVG rendering in light mode matches page background
- [x] Check SVG rendering in dark mode matches page background  
- [x] Verify SVGs are properly sized (max 450px width)
- [x] Test on untitled post with multiple SVGs

🤖 Generated with [Claude Code](https://claude.ai/code)