### PR TITLE
fix: prevent Chrome Translate from breaking interactive components

### DIFF
--- a/app/[slug]/markdown.tsx
+++ b/app/[slug]/markdown.tsx
@@ -88,12 +88,14 @@ export function LI(props: React.ComponentProps<"li">) {
 }
 
 export function Pre({
+  className = "",
   style,
   ...props
 }: React.ComponentProps<"pre">) {
   return (
     <pre
-      className="-mx-4 overflow-y-auto p-4 text-sm"
+      className={`${className} -mx-4 overflow-y-auto p-4 text-sm notranslate`.trim()}
+      translate="no"
       {...props}
       style={{
         ...style,
@@ -110,17 +112,23 @@ export function Pre({
 }
 
 export function Code({
-  className,
+  className = "",
   ...props
 }: React.ComponentProps<"code"> & { "data-language"?: string }) {
   // Code blocks have data-language from rehype-pretty-code (defaultLang ensures all blocks have it)
   if ("data-language" in props) {
-    return <code className={className} {...props} />;
+    return (
+      <code
+        className={`${className} notranslate`.trim()}
+        translate="no"
+        {...props}
+      />
+    );
   }
   // Inline code styling
   return (
-    <code
-      className="rounded-[10px] bg-[--inlineCode-bg] text-[--inlineCode-text] px-[0.2em] py-[0.15em] whitespace-normal"
+    <span
+      className={`${className} rounded-[10px] bg-[--inlineCode-bg] text-[--inlineCode-text] px-[0.2em] py-[0.15em] whitespace-normal font-mono`.trim()}
       {...props}
     />
   );

--- a/app/[slug]/markdown.tsx
+++ b/app/[slug]/markdown.tsx
@@ -127,7 +127,7 @@ export function Code({
   }
   // Inline code styling
   return (
-    <span
+    <code
       className={`${className} rounded-[10px] bg-[--inlineCode-bg] text-[--inlineCode-text] px-[0.2em] py-[0.15em] whitespace-normal font-mono`.trim()}
       {...props}
     />

--- a/public/a-social-filesystem/components.js
+++ b/public/a-social-filesystem/components.js
@@ -81,7 +81,12 @@ export function RecentPlays() {
   }, [isVisible]);
 
   return (
-    <div ref={containerRef} className="my-6 rounded-lg bg-black/[0.03] dark:bg-white/[0.03] px-4 py-3" style={{ fontFamily: 'system-ui, -apple-system, "Segoe UI", Roboto, sans-serif', minHeight: '13rem' }}>
+    <div
+      ref={containerRef}
+      className="my-6 rounded-lg bg-black/[0.03] dark:bg-white/[0.03] px-4 py-3 notranslate"
+      translate="no"
+      style={{ fontFamily: 'system-ui, -apple-system, "Segoe UI", Roboto, sans-serif', minHeight: '13rem' }}
+    >
       <p className="flex items-center gap-2 text-[--text-secondary] text-sm">
         {status === "connecting" && "tuning in..."}
         {status === "connected" && (

--- a/public/impossible-components/client.js
+++ b/public/impossible-components/client.js
@@ -5,7 +5,7 @@ import { Fragment, useState } from "react";
 export function GreetingFrontend({ color }) {
   const [yourName, setYourName] = useState("Alice");
   return (
-    <div className="font-sans text-xl">
+    <div className="font-sans text-xl notranslate" translate="no">
       <input
         className="border-2 mb-1 p-1 rounded-lg"
         placeholder="What's your name?"
@@ -22,7 +22,7 @@ export function GreetingFrontend({ color }) {
 export function GreetingFrontend_2({ color }) {
   const [yourName, setYourName] = useState("Alice");
   return (
-    <div className="font-sans text-xl">
+    <div className="font-sans text-xl notranslate" translate="no">
       <input
         className="border-2 mb-1 p-1 rounded-lg"
         placeholder="What's your name?"
@@ -44,7 +44,7 @@ export function SortableList({ items }) {
   const [isReversed, setIsReversed] = useState(false);
   const sortedItems = isReversed ? items.toReversed() : items;
   return (
-    <div className="font-sans text-sm">
+    <div className="font-sans text-sm notranslate" translate="no">
       <button
         className="mb-4 font-semibold text-md border-2 px-4 py-2 rounded-md bg-purple-500 hover:opacity-95 hover:scale-105 transform text-white"
         onClick={() => setIsReversed(!isReversed)}
@@ -71,7 +71,7 @@ export function SortableList_2({ items }) {
   }
   const sortedItems = isReversed ? filteredItems.toReversed() : filteredItems;
   return (
-    <div className="font-sans text-sm">
+    <div className="font-sans text-sm notranslate" translate="no">
       <button
         className="mb-4 font-semibold text-md border-2 px-4 py-2 rounded-md bg-purple-500 hover:opacity-95 hover:scale-105 transform text-white"
         onClick={() => setIsReversed(!isReversed)}
@@ -121,7 +121,7 @@ export function SortableList_3({ items }) {
   }
   const sortedItems = isReversed ? filteredItems.toReversed() : filteredItems;
   return (
-    <div className="font-sans text-sm">
+    <div className="font-sans text-sm notranslate" translate="no">
       <>
         <button
           className="mb-4 font-semibold text-md border-2 px-4 py-2 rounded-md bg-purple-500 hover:opacity-95 hover:scale-105 transform text-white"
@@ -156,7 +156,7 @@ export function SortableList_4({ items }) {
   }
   const sortedItems = isReversed ? filteredItems.toReversed() : filteredItems;
   return (
-    <>
+    <div className="notranslate" translate="no">
       <div className="font-sans text-sm">
         <button
           className="mb-4 font-semibold text-md border-2 px-4 py-2 rounded-md bg-purple-500 hover:opacity-95 hover:scale-105 transform text-white"
@@ -176,6 +176,6 @@ export function SortableList_4({ items }) {
           <li key={item.id}>{item.content}</li>
         ))}
       </ul>
-    </>
+    </div>
   );
 }

--- a/public/the-two-reacts/counter.js
+++ b/public/the-two-reacts/counter.js
@@ -6,7 +6,8 @@ export function Counter() {
   const [count, setCount] = useState(0);
   return (
     <button
-      className="dark:color-white rounded-lg bg-purple-700 px-2 py-1 font-sans font-semibold text-white focus:ring active:bg-purple-600"
+      className="dark:color-white rounded-lg bg-purple-700 px-2 py-1 font-sans font-semibold text-white focus:ring active:bg-purple-600 notranslate"
+      translate="no"
       onClick={() => setCount(count + 1)}
     >
       You clicked me {count} times


### PR DESCRIPTION
1. the-two-reacts 
link: https://overreacted.io/the-two-reacts/

https://github.com/user-attachments/assets/8704023f-9467-4afd-be9d-42cf41db6b20

2. impossible-components
link: https://overreacted.io/impossible-components/

https://github.com/user-attachments/assets/ea8c9354-d306-4c6d-b1e6-f2409aab27e8

3. a-social-filesystem
link: https://overreacted.io/a-social-filesystem/

https://github.com/user-attachments/assets/45d1c8b1-7b73-4de0-ab80-389877726d7e


### Description

This PR addresses the Chrome Translate issues reported in #873.

#### 1. Interactive component breakage

Dynamic client-side components (such as `<Counter />` and `<RecentPlays />`) could stop responding after browser translation.

This happens because translation tools mutate DOM text nodes inside React-managed components, which can interfere with React reconciliation during later state updates.

**Fix**

Added `translate="no"` and `notranslate` to dynamic interactive components so translation tools leave React-controlled DOM untouched.

---

#### 2. Code content preservation

Browser translation could also interfere with rendered code content.

**Fix**

Applied `translate="no"` and `notranslate` to code blocks to preserve code content and prevent translation-related corruption.

---

#### Inline code ordering

I also investigated the inline code ordering issue reported in translated sentences.

A local experiment showed that replacing semantic `<code>` with `<span>` improved Chrome Translate behavior, but this change was intentionally excluded from this PR to preserve semantic HTML.

This issue likely requires a separate discussion or a more targeted solution.

---

### Verification

Tested locally and confirmed that `npm run build` completes successfully and SSG pages are generated as expected.

Closes #873