### PR TITLE
Adopt Cache Components

### DIFF
--- a/app/[slug]/opengraph-image.tsx
+++ b/app/[slug]/opengraph-image.tsx
@@ -2,16 +2,19 @@ import { readdir, readFile } from "node:fs/promises";
 import matter from "gray-matter";
 import { size, contentType, generatePostImage } from "../../og/generateImage";
 
-export const dynamic = "force-static";
 export const alt = "Overreacted";
 export { size, contentType };
 
+async function getPostTitle(slug: string) {
+  "use cache";
+  const file = await readFile("./public/" + slug + "/index.md", "utf8");
+  const { data } = matter(file);
+  return data.title;
+}
+
 export default async function Image({ params }) {
   const { slug } = await params;
-  const filename = "./public/" + slug + "/index.md";
-  const file = await readFile(filename, "utf8");
-  const { data } = matter(file);
-  return generatePostImage({ title: data.title });
+  return generatePostImage({ title: await getPostTitle(slug) });
 }
 
 // Has to be declared locally rather than re-exported from ./page: the build's

--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -20,6 +20,7 @@ export default async function PostPage({
 }: {
   params: Promise<{ slug: string }>;
 }) {
+  "use cache";
   const { slug } = await params;
   const filename = "./public/" + slug + "/index.md";
   const file = await readFile(filename, "utf8");
@@ -224,6 +225,7 @@ export async function generateMetadata({
 }: {
   params: Promise<{ slug: string }>;
 }) {
+  "use cache";
   const { slug } = await params;
   const file = await readFile("./public/" + slug + "/index.md", "utf8");
   let { data } = matter(file);

--- a/app/atom.xml/route.ts
+++ b/app/atom.xml/route.ts
@@ -1,8 +1,11 @@
 import { generateFeed } from "../posts";
 
-export const dynamic = "force-static";
+async function getAtomFeed() {
+  "use cache";
+  const feed = await generateFeed();
+  return feed.atom1();
+}
 
 export async function GET() {
-  const feed = await generateFeed();
-  return new Response(feed.atom1());
+  return new Response(await getAtomFeed());
 }

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -1,7 +1,5 @@
 import { getPosts } from "../posts";
 
-export const dynamic = "force-static";
-
 export async function GET() {
   const posts = await getPosts();
   const lines = [

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,6 +1,5 @@
 import { size, contentType, generateHomeImage } from "../og/generateImage";
 
-export const dynamic = "force-static";
 export const alt = "Overreacted";
 export { size, contentType };
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import { sans } from "./fonts";
 export { metadata };
 
 export default async function Home() {
+  "use cache";
   const posts = await getPosts();
   return (
     <div className="relative -top-[10px] flex flex-col gap-8">

--- a/app/posts.ts
+++ b/app/posts.ts
@@ -1,6 +1,7 @@
 import { readdir, readFile } from "fs/promises";
 import matter from "gray-matter";
 import { Feed } from "feed";
+import { cacheLife } from "next/cache";
 
 export interface Post {
   slug: string;
@@ -26,6 +27,8 @@ export const metadata = {
 };
 
 export async function getPosts(): Promise<Post[]> {
+  "use cache";
+  cacheLife("max");
   const entries = await readdir("./public/", { withFileTypes: true });
   const dirs = entries
     .filter((entry) => entry.isDirectory())

--- a/app/rss.xml/route.ts
+++ b/app/rss.xml/route.ts
@@ -1,8 +1,11 @@
 import { generateFeed } from "../posts";
 
-export const dynamic = "force-static";
+async function getRssFeed() {
+  "use cache";
+  const feed = await generateFeed();
+  return feed.rss2();
+}
 
 export async function GET() {
-  const feed = await generateFeed();
-  return new Response(feed.rss2());
+  return new Response(await getRssFeed());
 }

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   trailingSlash: true,
+  cacheComponents: true,
   experimental: {
     viewTransition: true,
   },

--- a/og/generateImage.js
+++ b/og/generateImage.js
@@ -138,37 +138,36 @@ export async function generatePostImage({ title }) {
 }
 
 async function generateImage(jsx) {
+  // Read fonts fresh per call: ImageResponse detaches the underlying
+  // ArrayBuffer, so a shared buffer breaks the next image with
+  // "First argument to DataView constructor must be an ArrayBuffer".
+  const [montserratExtraBold, merriweatherRegular, merriweatherItalic] =
+    await Promise.all([
+      readFile(join(process.cwd(), "og/Montserrat-ExtraBold.ttf")),
+      readFile(join(process.cwd(), "og/Merriweather-Regular.ttf")),
+      readFile(join(process.cwd(), "og/Merriweather-Italic.ttf")),
+    ]);
   return new ImageResponse(jsx, {
     ...size,
     fonts: [
       {
         name: "Montserrat",
-        data: await montserratExtraBold,
+        data: montserratExtraBold,
         style: "normal",
         weight: 900,
       },
       {
         name: "Merriweather",
-        data: await merriweatherRegular,
+        data: merriweatherRegular,
         style: "normal",
         weight: 500,
       },
       {
         name: "Merriweather",
-        data: await merriweatherItalic,
+        data: merriweatherItalic,
         style: "italic",
         weight: 500,
       },
     ],
   });
 }
-
-const montserratExtraBold = readFile(
-  join(process.cwd(), "og/Montserrat-ExtraBold.ttf"),
-);
-const merriweatherRegular = readFile(
-  join(process.cwd(), "og/Merriweather-Regular.ttf"),
-);
-const merriweatherItalic = readFile(
-  join(process.cwd(), "og/Merriweather-Italic.ttf"),
-);


### PR DESCRIPTION
Turns on `cacheComponents: true` and brings the app to a green build under it. `getPosts` (the shared fs-backed data layer) moves to `"use cache"` with `cacheLife("max")`, and `Home`, `PostPage`, and `generateMetadata` get `"use cache"` so their uncached `readFile`s — and the `new Date()` staleness color in `page.tsx` — resolve at cache time. The `atom.xml`/`rss.xml`/`llms.txt` route handlers and the two OG-image routes drop `export const dynamic = "force-static"` in favor of cached helpers.

`og/generateImage.js` now reads its font files fresh inside `generateImage` rather than from shared module-level buffers: `ImageResponse` detaches the underlying `ArrayBuffer`, so the shared buffer broke every OG image after the first with `First argument to DataView constructor must be an ArrayBuffer`. The two OG-image routes stay dynamic (`ƒ`) since they read fonts per request; `/`, the feeds, and `llms.txt` prerender static and the 58 posts partially prerender.

Unknown slugs return 500 rather than 404 — `readFile` in `PostPage`/`generateMetadata` throws `ENOENT` with no `notFound()` guard. Pre-existing (reproduces with the flag off), so left out of this PR.
